### PR TITLE
arty/base and nexys_video/base: Fix ddr3 and reset

### DIFF
--- a/targets/arty/base.py
+++ b/targets/arty/base.py
@@ -26,7 +26,7 @@ class _CRG(Module):
         self.clock_domains.cd_clk50 = ClockDomain()
 
         clk100 = platform.request("clk100")
-        rst = platform.request("cpu_reset")
+        rst = ~platform.request("cpu_reset")
 
         pll_locked = Signal()
         pll_fb = Signal()
@@ -69,9 +69,9 @@ class _CRG(Module):
             Instance("BUFG", i_I=pll_sys4x_dqs, o_O=self.cd_sys4x_dqs.clk),
             Instance("BUFG", i_I=pll_clk200, o_O=self.cd_clk200.clk),
             Instance("BUFG", i_I=pll_clk50, o_O=self.cd_clk50.clk),
-            AsyncResetSynchronizer(self.cd_sys, ~pll_locked | ~rst),
+            AsyncResetSynchronizer(self.cd_sys, ~pll_locked | rst),
             AsyncResetSynchronizer(self.cd_clk200, ~pll_locked | rst),
-            AsyncResetSynchronizer(self.cd_clk50, ~pll_locked | ~rst),
+            AsyncResetSynchronizer(self.cd_clk50, ~pll_locked | rst),
         ]
 
         reset_counter = Signal(4, reset=15)
@@ -158,5 +158,6 @@ class BaseSoC(SoCSDRAM):
                             sdram_module.geom_settings,
                             sdram_module.timing_settings,
                             controller_settings=controller_settings)
+
 
 SoC = BaseSoC

--- a/targets/arty/base.py
+++ b/targets/arty/base.py
@@ -148,8 +148,8 @@ class BaseSoC(SoCSDRAM):
         sdram_module = MT41K128M16(self.clk_freq, "1:4")
         self.submodules.ddrphy = a7ddrphy.A7DDRPHY(
             platform.request("ddram"))
-        self.add_constant("A7DDRPHY_BITSLIP", 2)
-        self.add_constant("A7DDRPHY_DELAY", 6)
+        self.add_constant("READ_LEVELING_BITSLIP", 3)
+        self.add_constant("READ_LEVELING_DELAY", 14)
         controller_settings = ControllerSettings(
             with_bandwidth=True,
             cmd_buffer_depth=8,

--- a/targets/nexys_video/base.py
+++ b/targets/nexys_video/base.py
@@ -127,8 +127,8 @@ class BaseSoC(SoCSDRAM):
 
         # sdram
         self.submodules.ddrphy = a7ddrphy.A7DDRPHY(platform.request("ddram"))
-        self.add_constant("A7DDRPHY_BITSLIP", 3)
-        self.add_constant("A7DDRPHY_DELAY", 14)
+        self.add_constant("READ_LEVELING_BITSLIP", 3)
+        self.add_constant("READ_LEVELING_DELAY", 14)
         sdram_module = MT41K256M16(self.clk_freq, "1:4")
         self.register_sdram(self.ddrphy,
                             sdram_module.geom_settings,


### PR DESCRIPTION
Changes to: 
* ddr3 read leveling parameters for arty and nexys_video
* reset signal polarity on arty