### PR TITLE
build-micropython.sh: new URL, build micropython.bin

### DIFF
--- a/scripts/build-micropython.sh
+++ b/scripts/build-micropython.sh
@@ -43,7 +43,7 @@ MPY_SRC_DIR=$TOP_DIR/third_party/micropython
 if [ ! -d "$MPY_SRC_DIR" ]; then
 	(
 		cd $(dirname $MPY_SRC_DIR)
-		git clone https://github.com/upy-fpga/micropython.git
+		git clone https://github.com/fupy/micropython.git
 		cd $MPY_SRC_DIR
 		git submodule update --init
 	)
@@ -75,6 +75,7 @@ make V=1 -C $(realpath ../../../../third_party/micropython/litex/) -j$JOBS
 cd $OLD_DIR
 
 # Generate a firmware image suitable for flashing.
-#python -m litex.soc.tools.mkmscimg -f $TARGET_MPY_BUILD_DIR/firmware.bin -o $TARGET_MPY_BUILD_DIR/firmware.fbi
-#/usr/bin/env python mkimage.py $MISOC_EXTRA_CMDLINE $LITEX_EXTRA_CMDLINE --output-file=$TARGET_BUILD_DIR/micropython.bin --override-firmware=$TARGET_MPY_BUILD_DIR/firmware.fbi
 make image
+#
+python -m litex.soc.tools.mkmscimg -f $TARGET_MPY_BUILD_DIR/firmware.bin -o $TARGET_MPY_BUILD_DIR/firmware.fbi
+/usr/bin/env python mkimage.py $MISOC_EXTRA_CMDLINE $LITEX_EXTRA_CMDLINE --output-file=$TARGET_BUILD_DIR/micropython.bin --override-firmware=$TARGET_MPY_BUILD_DIR/firmware.fbi

--- a/scripts/build-micropython.sh
+++ b/scripts/build-micropython.sh
@@ -33,6 +33,11 @@ make info
 set -x
 set -e
 
+if [ "$FIRMWARE" != "micropython" ]; then
+        echo "When building MicroPython you should set FIRMWARE to 'micropython'."
+        exit 1
+fi
+
 # Install a toolchain with the newlib standard library
 if ! $CPU-elf-newlib-gcc --version > /dev/null 2>&1; then
 	conda install gcc-$CPU-elf-newlib
@@ -76,6 +81,3 @@ cd $OLD_DIR
 
 # Generate a firmware image suitable for flashing.
 make image
-#
-python -m litex.soc.tools.mkmscimg -f $TARGET_MPY_BUILD_DIR/firmware.bin -o $TARGET_MPY_BUILD_DIR/firmware.fbi
-/usr/bin/env python mkimage.py $MISOC_EXTRA_CMDLINE $LITEX_EXTRA_CMDLINE --output-file=$TARGET_BUILD_DIR/micropython.bin --override-firmware=$TARGET_MPY_BUILD_DIR/firmware.fbi


### PR DESCRIPTION
Updated git repo URL for micropython.git; re-enabled building of combined
micropython.bin as it is useful on Nuamto Mimas v2.  Tested with lm32
soft CPU; appears not to work with or1k soft CPU at this time ("system.h
not found")