### PR TITLE
Make qemu script work on Arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ tftpd_start:
 	sudo true
 	@if sudo which atftpd >/dev/null ; then \
 		echo "Starting aftpd"; \
-		sudo atftpd --verbose --bind-address $(TFTP_IPRANGE).100 --daemon --logfile /dev/stdout --no-fork --user $(shell whoami) $(TFTPD_DIR) & \
+		sudo atftpd --verbose --bind-address $(TFTP_IPRANGE).100 --daemon --logfile /dev/stdout --no-fork --user $(shell whoami) --group $(shell whoami) $(TFTPD_DIR) & \
 	elif sudo which in.tftpd >/dev/null; then \
 		echo "Starting in.tftpd"; \
 		sudo in.tftpd --verbose --listen --address $(TFTP_IPRANGE).100 --user $(shell whoami) -s $(TFTPD_DIR) & \

--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ tftpd_start:
 	sudo true
 	@if sudo which atftpd >/dev/null ; then \
 		echo "Starting aftpd"; \
-		sudo atftpd --verbose --bind-address $(TFTP_IPRANGE).100 --daemon --logfile /dev/stdout --no-fork --user $(shell whoami) --group $(shell whoami) $(TFTPD_DIR) & \
+		sudo atftpd --verbose --bind-address $(TFTP_IPRANGE).100 --daemon --logfile /dev/stdout --no-fork --user $(shell whoami) --group $(shell id -gn) $(TFTPD_DIR) & \
 	elif sudo which in.tftpd >/dev/null; then \
 		echo "Starting in.tftpd"; \
 		sudo in.tftpd --verbose --listen --address $(TFTP_IPRANGE).100 --user $(shell whoami) -s $(TFTPD_DIR) & \

--- a/scripts/build-qemu.sh
+++ b/scripts/build-qemu.sh
@@ -129,7 +129,15 @@ if grep -q ETHMAC_BASE $TARGET_BUILD_DIR/software/include/generated/csr.h; then
 				exit 1
 			fi
 			sudo chown $(whoami) /dev/net/tap0
-			sudo ifconfig tap0 $TFTP_IPRANGE.100 up
+			if sudo which ifconifg > /dev/null; then
+				sudo ifconfig tap0 $TFTP_IPRANGE.100 up
+			elif sudo which ip > /dev/null; then
+				sudo ip addr add $TFTP_IPRANGE.100/24 dev tap0
+				sudo ip link set dev tap0 up
+			else
+				echo "Unable to find tool to configure tap0 address"
+				exit 1
+			fi
 			make tftpd_start
 		fi
 		EXTRA_ARGS+=("-net nic -net tap,ifname=tap0,script=no,downscript=no")


### PR DESCRIPTION
- Set --group for atftpd (the default group it uses doesn't exist on arch)
- Use `ip` instead of `ifconfig` if not available