### PR TITLE
TFTP: Support alternate TFTP Server Port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ export TFTP_IPRANGE
 TFTPD_DIR ?= build/tftpd/
 
 # Default TFTP Server Port to IANA well known UDP/69
-TFTP_SERVER_PORT ?= 69
+TFTP_SERVER_PORT ?= 6069
 
 # Couple of Python settings.
 # ---------------------------------

--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,12 @@ TFTP_IPRANGE ?= 192.168.100
 export TFTP_IPRANGE
 TFTPD_DIR ?= build/tftpd/
 
-# Default TFTP Server Port to IANA well known UDP/69
+# Well known TFTP Server Port is UDP/69
+# Default to high numbered port so we can run TFTP server as non-root
+# (export into shell environment to use during building firmware BIOS)
+#
 TFTP_SERVER_PORT ?= 6069
+export TFTP_SERVER_PORT
 
 # Couple of Python settings.
 # ---------------------------------
@@ -305,6 +309,12 @@ bios-flash: $(BIOS_FILE) bios-flash-$(PLATFORM)
 # We can run the TFTP server as the user if port >= 1024
 # otherwise we need to run as root using sudo
 
+ATFTPD=$(shell which atftpd)
+ATFTPD?=/usr/sbin/atftpd
+
+IN_TFTPD=$(shell which in.tfptd)
+IN_TFTPD=?=/usr/sbin/in.tftpd
+
 tftp: $(FIRMWARE_FILEBASE).bin
 	mkdir -p $(TFTPD_DIR)
 	cp $(FIRMWARE_FILEBASE).bin $(TFTPD_DIR)/boot.bin
@@ -319,19 +329,19 @@ tftpd_start:
 		echo "Root required to run TFTP Server, will use sudo"; \
 		sudo true; \
 	fi
-	@if sudo which atftpd >/dev/null ; then \
+	@if [ -x "$(ATFTPD)" ]; then \
 		echo "Starting aftpd"; \
 		if [ $(TFTP_SERVER_PORT) -lt 1024 ]; then \
-			sudo atftpd --verbose --bind-address $(TFTP_IPRANGE).100 --port $(TFTP_SERVER_PORT) --daemon --logfile /dev/stdout --no-fork --user $(shell whoami) --group $(shell id -gn) $(TFTPD_DIR) & \
+			sudo "$(ATFTPD)" --verbose --bind-address $(TFTP_IPRANGE).100 --port $(TFTP_SERVER_PORT) --daemon --logfile /dev/stdout --no-fork --user $(shell whoami) --group $(shell id -gn) $(TFTPD_DIR) & \
 		else \
-			atftpd --verbose --bind-address $(TFTP_IPRANGE).100 --port $(TFTP_SERVER_PORT) --daemon --logfile /dev/stdout --no-fork --user $(shell whoami) --group $(shell id -gn) $(TFTPD_DIR) & \
+			"$(ATFTPD)" --verbose --bind-address $(TFTP_IPRANGE).100 --port $(TFTP_SERVER_PORT) --daemon --logfile /dev/stdout --no-fork --user $(shell whoami) --group $(shell id -gn) $(TFTPD_DIR) & \
 		fi \
-	elif sudo which in.tftpd >/dev/null; then \
+	elif [ -x "$(IN_TFTPD)" ]; then \
 		echo "Starting in.tftpd"; \
 		if [ $(TFTP_SERVER_PORT) -lt 1024 ]; then \
-			sudo in.tftpd --verbose --listen --address $(TFTP_IPRANGE).100 --port-range $(TFTP_SERVER_PORT):$(TFTP_SERVER_PORT) --user $(shell whoami) -s $(TFTPD_DIR) & \
+			sudo "$(IN_TFTPD)" --verbose --listen --address $(TFTP_IPRANGE).100 --port-range $(TFTP_SERVER_PORT):$(TFTP_SERVER_PORT) --user $(shell whoami) -s $(TFTPD_DIR) & \
 		else \
-			in.tftpd --verbose --listen --address $(TFTP_IPRANGE).100 --port-range $(TFTP_SERVER_PORT):$(TFTP_SERVER_PORT) --user $(shell whoami) -s $(TFTPD_DIR) & \
+			"$(IN_TFTPD)" --verbose --listen --address $(TFTP_IPRANGE).100 --port-range $(TFTP_SERVER_PORT):$(TFTP_SERVER_PORT) --user $(shell whoami) -s $(TFTPD_DIR) & \
 		fi \
 	else \
 		echo "Cannot find an appropriate tftpd binary to launch the server."; \
@@ -372,6 +382,7 @@ env:
 	@echo "export BIOS_FILE='$(BIOS_FILE)'"
 	@# Network settings
 	@echo "export TFTP_IPRANGE='$(TFTP_IPRANGE)'"
+	@echo "export TFTP_SERVER_PORT='$(TFTP_SERVER_PORT)'"
 	@echo "export TFTPD_DIR='$(TFTPD_DIR)'"
 
 info:


### PR DESCRIPTION
Updates litex submodule pin to include [Alternate TFTP Server Port BIOS support](https://github.com/enjoy-digital/litex/pull/52), where if BIOS is built with TFTP_SERVER_PORT set then it will try TFTP from that port first before falling back to UDP/69.

Update Makefile to start TFTP server on port specified in TFTP_SERVER_PORT if set (defaulting to UDP/69).  If TFTP_SERVER_PORT is >= 1024 then TFTP server is started as user, without using sudo; otherwise TFTP server is started via sudo as before.

`atftpd` path tested; `in.tftpd` path written but not tested.

(Writing this change overlapped with merging of another change around TFTP group, so I've ended up rebase/squashing it into a single commit, but I think I've kept the sense of the overlapping change; I had to do the same thing to be able to run as non-root, otherwise setgid() failed.)