### PR TITLE
arty: Support "make firmware-load" for F=micropython

### DIFF
--- a/targets/arty/Makefile.mk
+++ b/targets/arty/Makefile.mk
@@ -25,7 +25,8 @@ gateware-flash-$(PLATFORM): gateware-flash-py
 
 # Firmware
 firmware-load-$(PLATFORM):
-	flterm --port=$(COMM_PORT) --kernel=$(TARGET_BUILD_DIR)/software/firmware/firmware.bin --speed=$(BAUD)
+	flterm --port=$(COMM_PORT) --kernel=$(FIRMWARE_FILEBASE).bin --speed=$(BAUD)
+
 
 firmware-flash-$(PLATFORM): firmwage-flash-py
 	@true


### PR DESCRIPTION
Copied over "make firmware-load" target from `mimasv2/Makefile.mk` so that firmware is not hard coded to be H2U firmware, but instead depends on `F=....` value.