### PR TITLE
tftp: Fix issues with in.tftp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,8 +317,8 @@ bios-flash: $(BIOS_FILE) bios-flash-$(PLATFORM)
 ATFTPD=$(shell which atftpd)
 ATFTPD?=/usr/sbin/atftpd
 
-IN_TFTPD=$(shell which in.tfptd)
-IN_TFTPD=?=/usr/sbin/in.tftpd
+IN_TFTPD=$(shell which in.tftpd)
+IN_TFTPD?=/usr/sbin/in.tftpd
 
 tftp: $(FIRMWARE_FILEBASE).bin
 	mkdir -p $(TFTPD_DIR)
@@ -349,9 +349,9 @@ tftpd_start:
 	elif [ -x "$(IN_TFTPD)" ]; then \
 		echo "Starting in.tftpd"; \
 		if [ $(TFTP_SERVER_PORT) -lt 1024 ]; then \
-			sudo "$(IN_TFTPD)" --verbose --listen --address $(TFTP_IPRANGE).100 --port-range $(TFTP_SERVER_PORT):$(TFTP_SERVER_PORT) --user $(shell whoami) -s $(TFTPD_DIR) & \
+			sudo "$(IN_TFTPD)" --verbose --listen --address $(TFTP_IPRANGE).100:$(TFTP_SERVER_PORT) --user $(shell whoami) -s $(TFTPD_DIR) & \
 		else \
-			"$(IN_TFTPD)" --verbose --listen --address $(TFTP_IPRANGE).100 --port-range $(TFTP_SERVER_PORT):$(TFTP_SERVER_PORT) --user $(shell whoami) -s $(TFTPD_DIR) & \
+			"$(IN_TFTPD)" --verbose --listen --address $(TFTP_IPRANGE).100:$(TFTP_SERVER_PORT) --user $(shell whoami) -s $(TFTPD_DIR) & \
 		fi \
 	else \
 		echo "Cannot find an appropriate tftpd binary to launch the server."; \


### PR DESCRIPTION
I run on fedora and us in.tftp, it was not working as there were
a few typos in variables and the port argument I dont think does what
it was expected to.