### PR TITLE
Makefile: check if submodules are current, warn if not

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,9 +208,32 @@ image-flash-py: image
 .PHONY: image image-load image-flash image-flash-py image-flash-$(PLATFORM) image-load-$(PLATFORM)
 .NOTPARALLEL: image-load image-flash image-flash-py image-flash-$(PLATFORM) image-load-$(PLATFORM)
 
+# Submodule checks
+#
+# Generate third_party/*/.git dependencies to force checkouts of submodules
+#
+# Also check for non-matching submodules, and warn that update might be
+# needed (but do not force to match, as that makes development difficult)
+# This is indicated by a "git submodule status" that does not start with
+# a space (" ").
+#
 LITEX_SUBMODULES=litex litedram liteeth litepcie litesata litescope liteusb litevideo
 litex-submodules: $(addsuffix /.git,$(addprefix third_party/,$(LITEX_SUBMODULES)))
-	@true
+	@if git submodule status --recursive | grep "^[^ ]" >/dev/null; then \
+		echo ""; \
+		echo "***************************************************************************"; \
+		echo "WARNING: the following submodules do not match expected commit:"; \
+		echo ""; \
+		git submodule status --recursive | grep "^[^ ]"; \
+		echo ""; \
+		echo "If you are not developing in submodules you may need to run:"; \
+		echo ""; \
+		echo "git submodule update --init --recursive"; \
+		echo ""; \
+		echo "manually to bring everything back in sync with upstream"; \
+		echo "***************************************************************************"; \
+		echo ""; \
+	fi
 
 # Gateware - the stuff which configures the FPGA.
 # --------------------------------------


### PR DESCRIPTION
Make litex-submodules also check if submodules are "current" (ie,
match the sha1 indicated in the parent repository -- timvideos/litex-buildenv)
and if not, emit a warning that they are out of date.

Produces a warning like:

<pre>
***************************************************************************
WARNING: the following submodules do not match expected commit:

+dcbe02b33c7b898fe8b768e5d3aaac2e257ce728 third_party/litex (timvideos-2018-01-14-31-gdcbe02b)

If you are not developing in submodules you may need to run:

git submodule update --init --recursive

manually to bring everything back in sync with upstream
***************************************************************************
</pre>

NOTE: we do _not_ force update in the Makefile, as this would make it
difficult to test changes inside submodules by building at top level
(eg, building new litex firmware, gateware, etc).

Possible future enhancements:
1.  Bail out of makefile (eg, "exit 1") if a variable indicating "development"
    is not set;

2.  Forcibly run "git submodule update --init --recursive" if found to be
    out of date, unless a variable indicating "development" is set