### PR TITLE
tftpd: Fix in.tftpd alternate port syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,6 +343,10 @@ ATFTPD:=/usr/sbin/atftpd
 endif
 
 # Requires HPA in.tftpd not traditional BSD in.tftpd
+# Unfortunately in.tftpd seems to require root always
+# even if run as current user, otherwise it reports
+# "cannot set groups for user $USER"
+#
 IN_TFTPD:=$(shell which in.tfptd)
 ifeq ($(IN_TFTPD),)
 IN_TFTPD:=/usr/sbin/in.tftpd
@@ -358,7 +362,11 @@ tftpd_stop:
 		sudo true; \
 		sudo killall atftpd || sudo killall in.tftpd || true; \
 	else \
-		killall atftpd || killall in.tftpd || true; \
+		killall atftpd || \
+		if ps axuwww | grep -v grep | \
+			grep "[i]n.tftpd" >/dev/null 2>&1; then \
+				sudo killall in.tftpd; \
+		fi || true; \
 	fi
 
 tftpd_start:
@@ -379,7 +387,9 @@ tftpd_start:
 		if [ $(TFTP_SERVER_PORT) -lt 1024 ]; then \
 			sudo "$(IN_TFTPD)" --verbose --listen --address $(TFTP_IPRANGE).100:$(TFTP_SERVER_PORT)  --user $(shell whoami) -s $(TFTPD_DIR) & \
 		else \
-			"$(IN_TFTPD)" --verbose --listen --address $(TFTP_IPRANGE).100:$(TFTP_SERVER_PORT) --user $(shell whoami) -s $(TFTPD_DIR) & \
+			echo "Root required to run in.tftpd, will use sudo"; \
+			sudo true; \
+			sudo "$(IN_TFTPD)" --verbose --listen --address $(TFTP_IPRANGE).100:$(TFTP_SERVER_PORT) --user $(shell whoami) -s $(TFTPD_DIR) & \
 		fi \
 	else \
 		echo "Cannot find an appropriate tftpd binary to launch the server."; \

--- a/Makefile
+++ b/Makefile
@@ -342,6 +342,7 @@ ifeq ($(ATFTPD),)
 ATFTPD:=/usr/sbin/atftpd
 endif
 
+# Requires HPA in.tftpd not traditional BSD in.tftpd
 IN_TFTPD:=$(shell which in.tfptd)
 ifeq ($(IN_TFTPD),)
 IN_TFTPD:=/usr/sbin/in.tftpd
@@ -376,9 +377,9 @@ tftpd_start:
 	elif [ -x "$(IN_TFTPD)" ]; then \
 		echo "Starting in.tftpd"; \
 		if [ $(TFTP_SERVER_PORT) -lt 1024 ]; then \
-			sudo "$(IN_TFTPD)" --verbose --listen --address $(TFTP_IPRANGE).100 --port-range $(TFTP_SERVER_PORT):$(TFTP_SERVER_PORT) --user $(shell whoami) -s $(TFTPD_DIR) & \
+			sudo "$(IN_TFTPD)" --verbose --listen --address $(TFTP_IPRANGE).100:$(TFTP_SERVER_PORT)  --user $(shell whoami) -s $(TFTPD_DIR) & \
 		else \
-			"$(IN_TFTPD)" --verbose --listen --address $(TFTP_IPRANGE).100 --port-range $(TFTP_SERVER_PORT):$(TFTP_SERVER_PORT) --user $(shell whoami) -s $(TFTPD_DIR) & \
+			"$(IN_TFTPD)" --verbose --listen --address $(TFTP_IPRANGE).100:$(TFTP_SERVER_PORT) --user $(shell whoami) -s $(TFTPD_DIR) & \
 		fi \
 	else \
 		echo "Cannot find an appropriate tftpd binary to launch the server."; \

--- a/Makefile
+++ b/Makefile
@@ -347,7 +347,7 @@ endif
 # even if run as current user, otherwise it reports
 # "cannot set groups for user $USER"
 #
-IN_TFTPD:=$(shell which in.tfptd)
+IN_TFTPD:=$(shell which in.tftpd)
 ifeq ($(IN_TFTPD),)
 IN_TFTPD:=/usr/sbin/in.tftpd
 endif


### PR DESCRIPTION
This fixes the most obvious issue with running `in.tftpd` as a non-root user, by getting the syntax for the listening port correct.  Unfortunately at least when run on Ubuntu 16.04 the next result is:

    Feb  7 11:39:20 parthenon in.tftpd[1690]: cannot set groups for user ewen
    Feb  7 11:39:22 parthenon in.tftpd[1691]: cannot set groups for user ewen
    Feb  7 11:39:25 parthenon in.tftpd[1694]: cannot set groups for user ewen
    Feb  7 11:39:27 parthenon in.tftpd[1695]: cannot set groups for user ewen
    Feb  7 11:39:30 parthenon in.tftpd[1699]: cannot set groups for user ewen

(one for each TFTP REQ attempt).  I've found references to that going back 10 years, so I'm not 100% sure it will be possible to run `in.tftpd` as a non-`root` non-`nobody` (default user it changes to) user.  Needs more investigation, but pushing WIP pull request as this is clearly closer than previous attempt.