### PR TITLE
Makefile: make FIRMWARE=none work, Mimas v2 gateware-flash redirected to include BIOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,11 +178,13 @@ third_party/%/.git: .gitmodules
 # --------------------------------------
 ifeq ($(FIRMWARE),none)
 OVERRIDE_FIRMWARE=--override-firmware=none
+FIRMWARE_FBI=
 else
 OVERRIDE_FIRMWARE=--override-firmware=$(FIRMWARE_FILEBASE).fbi
+FIRMWARE_FBI=$(FIRMWARE_FILEBASE).fbi
 endif
 
-$(IMAGE_FILE): $(GATEWARE_FILEBASE).bin $(BIOS_FILE) $(FIRMWARE_FILEBASE).fbi
+$(IMAGE_FILE): $(GATEWARE_FILEBASE).bin $(BIOS_FILE) $(FIRMWARE_FBI)
 	$(PYTHON) mkimage.py \
 		$(MISOC_EXTRA_CMDLINE) $(LITEX_EXTRA_CMDLINE) $(MAKE_LITEX_EXTRA_CMDLINE) \
 		--override-gateware=$(GATEWARE_FILEBASE).bin \


### PR DESCRIPTION
If `FIRMWARE=none ` then the firmware will be omitted in `make image-flash`, but previously it would still try to build a `none.fbi` firmware image to include.  Move `.fbi` dependency into a variable so that we can replace it with a blank string if `FIRMWARE=none`.  Appears to work as expected for both `FIRMWARE=micropython` and `FIRMWARE=none`.