### PR TITLE
Fixes to PROMPT_COMMAND

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,7 @@ bios-flash: $(BIOS_FILE) bios-flash-$(PLATFORM)
 # We can run the TFTP server as the user if port >= 1024
 # otherwise we need to run as root using sudo
 
-ATFTPD:=$(shell which atftpd)
+ATFTPD:=$(shell which atftpd 2>/dev/null)
 ifeq ($(ATFTPD),)
 ATFTPD:=/usr/sbin/atftpd
 endif
@@ -349,7 +349,7 @@ endif
 # even if run as current user, otherwise it reports
 # "cannot set groups for user $USER"
 #
-IN_TFTPD:=$(shell which in.tftpd)
+IN_TFTPD:=$(shell which in.tftpd 2>/dev/null)
 ifeq ($(IN_TFTPD),)
 IN_TFTPD:=/usr/sbin/in.tftpd
 endif

--- a/scripts/enter-env.sh
+++ b/scripts/enter-env.sh
@@ -322,4 +322,4 @@ litex_buildenv_prompt() {
 		;;
 	esac
 }
-PROMPT_COMMAND=litex_buildenv_prompt
+PROMPT_COMMAND="litex_buildenv_prompt; ${PROMPT_COMMAND}"


### PR DESCRIPTION
Two misc fixes:
 - to remove errors when in.tftpd is not installed, and
 - prepend to PROMPT_COMMAND, rather than overwriting its contents.