### PR TITLE
scripts/build-micropython.sh: New MicroPython directory layout

### DIFF
--- a/scripts/build-micropython.sh
+++ b/scripts/build-micropython.sh
@@ -76,7 +76,7 @@ export BUILDINC_DIRECTORY="$(realpath $TARGET_BUILD_DIR/software/include)"
 export BUILD="$(realpath $TARGET_MPY_BUILD_DIR)"
 OLD_DIR=$PWD
 cd $TARGET_MPY_BUILD_DIR
-make V=1 -C $(realpath ../../../../third_party/micropython/litex/) -j$JOBS
+make V=1 -C $(realpath ../../../../third_party/micropython/ports/fupy/) -j$JOBS
 cd $OLD_DIR
 
 # Generate a firmware image suitable for flashing.


### PR DESCRIPTION
Update `scripts/build-micropython.sh` to match new directory layout in [updated FuPy MicroPython](https://github.com/fupy/micropython/pull/16) (updated as per https://github.com/fupy/micropython/pull/16).