### PR TITLE
Copy litex's libbase files into the micropython include path

### DIFF
--- a/scripts/build-micropython.sh
+++ b/scripts/build-micropython.sh
@@ -59,6 +59,16 @@ if [ ! -d $TARGET_BUILD_DIR/software/include/generated ]; then
 	make firmware
 fi
 
+# Copy in some litex platform specific files that MicroPython may need
+# in order to build; these need to end up in top level include directory
+# so that they are found by compiler/assembler.
+#
+LITEX_INCLUDE_BASE="$PWD/third_party/litex/litex/soc/software/include/base"
+
+for FILE in system.h csr-defs.h spr-defs.h; do
+	cp -p "$LITEX_INCLUDE_BASE/$FILE" "$TARGET_BUILD_DIR/software/include"
+done
+
 # Setup the micropython build directory
 TARGET_MPY_BUILD_DIR=$TARGET_BUILD_DIR/software/micropython
 if [ ! -e "$TARGET_MPY_BUILD_DIR/generated" ]; then


### PR DESCRIPTION
Partial attempt at getting `litex-buildenv` to build on `or1k` per https://github.com/fupy/micropython/issues/3.  This copies in `system.h`, `csr-defs.h` and `spr-defs.h` into `build` `software/include` directory so they can be included.

Currently still does not build, as there still issues with things being redefined:

<pre>
In file included from ../../py/mpprint.c:33:0:
../../py/mphal.h:46:6: error: conflicting types for 'mp_hal_stdout_tx_strn'
 void mp_hal_stdout_tx_strn(const char *str, size_t len);
      ^
In file included from ../../py/mphal.h:34:0,
                 from ../../py/mpprint.c:33:
./mphalport.h:13:20: note: previous definition of 'mp_hal_stdout_tx_strn' was here
 static inline void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
                    ^
../../py/mkrules.mk:47: recipe for target '/src/fpga/litex-buildenv/build/mimasv2_base_or1k/software/micropython/py/mpprint.o' failed
</pre>