### PR TITLE
Makefile: pass CPU_VARIANT through to firmware build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ ifeq ($(CPU_VARIANT),)
 FULL_CPU = $(CPU)
 else
 FULL_CPU = $(CPU).$(CPU_VARIANT)
-MAKE_LITEX_EXTRA_CMDLINE += -Ot cpu_variant $(CPU_VARIANT)
+MAKE_LITEX_EXTRA_CMDLINE += --cpu-variant=$(CPU_VARIANT)
 endif
 
 # Include platform specific targets


### PR DESCRIPTION
With this change we can build `CPU=lm32` `CPU_VARIANT=minimal`, and boot MicroPython on the Mimas V2 and the Arty.  It appears with the `-Ot cpu_variant minimal` the firmware does not get built in the right directory, which causes building MicroPython to fail (and possibly other things).

Boot on the Mimas V2 is *very* slow with this variant (possibly several timeouts).  Boot on the Arty seems relatively quick.  I've not attempted to debug the cause of this, but this trivial fix appears necessary for `CPU_VARIANT=minimal` to build.