### PR TITLE
tools: Read the BIOS maxsize from the SoC.

### DIFF
--- a/flash.py
+++ b/flash.py
@@ -18,6 +18,8 @@ def main():
 
     builddir = make.get_builddir(args)
     platform = make.get_platform(args)
+    soc = make.get_soc(args, platform)
+    bios_maxsize = make.get_bios_maxsize(args, soc)
 
     if args.mode == 'image':
         filename = make.get_image(builddir, "flash")
@@ -32,7 +34,7 @@ def main():
     elif args.mode == 'bios':
         filename = make.get_bios(builddir, "flash")
         address_start = platform.gateware_size
-        address_end = platform.gateware_size + make.BIOS_SIZE
+        address_end = platform.gateware_size + bios_maxsize
 
     elif args.mode == 'firmware':
         if args.override_firmware:
@@ -40,7 +42,7 @@ def main():
         else:
             filename = make.get_firmware(builddir, "flash")
 
-        address_start = platform.gateware_size + make.BIOS_SIZE
+        address_start = platform.gateware_size + bios_maxsize
         address_end = platform.spiflash_total_size
 
     elif args.mode == 'other':

--- a/mkimage.py
+++ b/mkimage.py
@@ -68,10 +68,12 @@ def main():
             "Firmware must be a MiSoC .fbi image.")
 
     platform = make.get_platform(args)
+    soc = make.get_soc(args, platform)
+    bios_size = make.get_bios_maxsize(args, soc)
 
     gateware_pos = 0
     bios_pos = platform.gateware_size
-    firmware_pos = platform.gateware_size + make.BIOS_SIZE
+    firmware_pos = platform.gateware_size + bios_size
 
     print()
     with open(output_file, "wb") as f:
@@ -97,7 +99,7 @@ def main():
             bios = "Skipped"
 
         # LiteX BIOS
-        assert len(bios_data) < make.BIOS_SIZE
+        assert len(bios_data) < bios_size
         f.seek(bios_pos)
         f.write(bios_data)
         print(("    BIOS @ 0x{:08x} ({:10} bytes) {:60}"


### PR DESCRIPTION
Means the larger BIOS size on or1k should be understood by `mkimage.py`
command.

Fixes #43.