### PR TITLE
qemu: Fix spiflash args as per deprecated args

### DIFF
--- a/scripts/build-qemu.sh
+++ b/scripts/build-qemu.sh
@@ -137,7 +137,8 @@ if grep -q 'SPIFLASH_BASE' $TARGET_BUILD_DIR/software/include/generated/mem.h; t
 		echo "Platform has unknown SPI flash - assuming m25p16!"
 		SPIFLASH_MODEL=m25p16
 	fi
-	EXTRA_ARGS+=("-drive if=mtd,format=qcow2,file=$TARGET_BUILD_DIR/qemu.qcow2,serial=$SPIFLASH_MODEL")
+	EXTRA_ARGS+=("-drive if=mtd,format=qcow2,file=$TARGET_BUILD_DIR/qemu.qcow2")
+	EXTRA_ARGS+=("-global litex_ssi.spiflash=$SPIFLASH_MODEL")
 fi
 
 # Ethernet


### PR DESCRIPTION
The arg available to specify serial for -drive was to be used for
specifying a drive serial number.  However, we we using it to specify
the flash driver.  This was a hack.

Introduce a driver option to be able to specify this on litex_ssi.  This
will then be read during ssi bus / drive initialization to initialize
the requested guest hardware.

By default we fall back to m25p80.

Example usage:
  -drive if=mtd,format=qcow2,file=build/arty_net_or1k//qemu.qcow2
  -global litex_ssi.spiflash=mx25l1606e

This depends on qemu patches to be used, over at: 
  https://github.com/stffrdhrn/qemu/tree/litex

If the patches are not available it the argument will just be ignored.