### PR TITLE
qemu: Allow qemu build to get upstream qemu after changes

### DIFF
--- a/scripts/build-qemu.sh
+++ b/scripts/build-qemu.sh
@@ -35,8 +35,10 @@ set -e
 
 QEMU_REMOTE="${QEMU_REMOTE:-https://github.com/timvideos/qemu-litex.git}"
 QEMU_BRANCH=${QEMU_BRANCH:-master}
-QEMU_REMOTE_NAME=timvideos-qemu-litex
+# extract the important part, i.e. 'github.com/timvideos/qemu-litex'
 QEMU_REMOTE_BIT=$(echo $QEMU_REMOTE | sed -e's-^.*://--' -e's/.git$//')
+# create the name for remote, i.e. 'timvideos-qemu-litex'
+QEMU_REMOTE_NAME=$(echo $QEMU_REMOTE_BIT | sed -e's-^[^/]*/--' | sed -e's@/@-@')
 QEMU_SRC_DIR=$TOP_DIR/third_party/qemu-litex
 if [ ! -d "$QEMU_SRC_DIR" ]; then
 	(
@@ -52,7 +54,7 @@ fi
 
 	# Add the remote if it doesn't exist
 	CURRENT_QEMU_REMOTE_NAME=$(git remote -v | grep fetch | grep "$QEMU_REMOTE_BIT" | sed -e's/\t.*$//')
-	if [ x"$CURRENT_QEMU_REMOTE_NAME" = x ]; then
+	if [ x"$CURRENT_QEMU_REMOTE_NAME" != x"$QEMU_REMOTE_NAME" ]; then
 		git remote add $QEMU_REMOTE_NAME $QEMU_REMOTE
 		CURRENT_QEMU_REMOTE_NAME=$QEMU_REMOTE_NAME
 	fi
@@ -64,6 +66,9 @@ fi
 	if [ "$(git rev-parse --abbrev-ref HEAD)" != "$QEMU_BRANCH" ]; then
 		git checkout $QEMU_BRANCH || \
 			git checkout "$CURRENT_QEMU_REMOTE_NAME/$QEMU_BRANCH" -b $QEMU_BRANCH
+	else
+		# If we are already on it, make sure we get the latest changes
+		git reset --hard "$CURRENT_QEMU_REMOTE_NAME/$QEMU_BRANCH"
 	fi
 )
 


### PR DESCRIPTION
Currently the qemu build will checkout the requested qemu branch if we
are not on it.  However, if we are on the correct branch it will not do
anything.  This is usually fine, but if upstream has changes it means
those changes will be be able to get picked up.

Add a 'git reset' to allow picking up of the upstream changes.

Also, currently the QEMU_REMOTE_NAME is always the same, that means if
we override the remote we will not really be able to add the new remote.
To enable this create the QEMU_REMOTE_NAME based on the remote url.