### PR TITLE
scripts: Move the GCC toolchain to 8.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -176,8 +176,8 @@ jobs:
   #- stage: Targets
   #  env: C=lm32 P=netv2        T="video"
 
-  - stage: Targets
-    env: C=lm32 P=nexys_video  T="video"
+  #- stage: Targets
+  #  env: C=lm32 P=nexys_video  T="video"
 
   - stage: Targets
     env: C=lm32 P=opsis        T="video"

--- a/.travis.yml
+++ b/.travis.yml
@@ -140,9 +140,6 @@ jobs:
   - stage: Targets
     env: C=vexriscv P=opsis    T="base net"
 
-  - stage: Targets
-    env: C=vexriscv.lite P=tinyfpga_bx F=stub T="base"
-
   # picorv32 Base targets
   - stage: Targets
     env: C=picorv32 P=arty     T="base net"

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,8 @@ jobs:
   - env: C=lm32 P=neso         T="base"
   - env: C=lm32 P=basys3       T="base"
   - env: C=lm32 P=cmod_a7      T="base"
+  - env: C=vexriscv.lite P=tinyfpga_bx F=stub T="base"
+  - env: C=picorv32      P=tinyfpga_bx F=stub T="base"
 
   include:
   #--------------------------------------------
@@ -127,6 +129,32 @@ jobs:
 
   - stage: Targets
     env: C=or1k P=pipistrello  T="base"
+
+  # vexriscv Base targets
+  - stage: Targets
+    env: C=vexriscv P=arty     T="base net"
+
+  - stage: Targets
+    env: C=vexriscv P=mimasv2  T="base"
+
+  - stage: Targets
+    env: C=vexriscv P=opsis    T="base net"
+
+  - stage: Targets
+    env: C=vexriscv.lite P=tinyfpga_bx F=stub T="base"
+
+  # picorv32 Base targets
+  - stage: Targets
+    env: C=picorv32 P=arty     T="base net"
+
+  - stage: Targets
+    env: C=picorv32 P=mimasv2  T="base"
+
+  - stage: Targets
+    env: C=picorv32 P=opsis    T="base net"
+
+  - stage: Targets
+    env: C=picorv32 P=tinyfpga_bx F=stub T="base"
 
   # Linux Targets
   #--------------------------------------------

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -26,22 +26,36 @@ function filelist() {
 }
 
 function build() {
-	export FULL_PLATFORM=$1
-	export TARGET=$2
-	export FULL_CPU=$3
+	SPLIT_REGEX="^\([^.]*\)\.\?\(.*\)\$"
 
-	if [ x"$4" != x"" ]; then
-		FIRMWARE=$4
-	else
-		unset $FIRMWARE
-	fi
-	export FIRMWARE
-
-	if [ -z "$FULL_PLATFORM" -o -z "$TARGET" -o -z "$FULL_CPU" ]; then
-		echo "usage: build FULL_PLATFORM TARGET FULL_CPU FIRMWARE"
-		echo "  got: build '$FULL_PLATFORM' '$TARGET' '$FULL_CPU' '$FIRMWARE'"
+	if [ -z "$1" -o -z "$2" -o -z "$3" ]; then
+		echo "usage: setup FULL_PLATFORM TARGET FULL_CPU FIRMWARE"
+		echo "  got: setup '$1' '$2' '$3' '$4'"
 		return 1
 	fi
+
+	#export FULL_PLATFORM=$1
+	export PLATFORM="$(echo $1 | sed -e"s/$SPLIT_REGEX/\1/")"
+	export PLATFORM_EXPANSION="$(echo $1 | sed -e"s/$SPLIT_REGEX/\2/")"
+
+	export TARGET="$2"
+
+	#export FULL_CPU=$3
+	export CPU="$(echo $3 | sed -e"s/$SPLIT_REGEX/\1/")"
+	export CPU_VARIANT="$(echo $3 | sed -e"s/$SPLIT_REGEX/\2/")"
+
+	if [ x$4 != x ]; then
+		FIRMWARE="$4"
+	else
+		unset FIRMWARE
+	fi
+
+	echo "--"
+	echo "PLATFORM=$PLATFORM PLATFORM_EXPANSION=$PLATFORM_EXPANSION"
+	echo "TARGET=$TARGET"
+	echo "CPU=$CPU CPU_VARIANT=$CPU_VARIANT"
+	echo "FIRMWARE=$FIRMWARE"
+	echo "--"
 
 	(
 	# Imports TARGET, PLATFORM, CPU and TARGET_BUILD_DIR from Makefile

--- a/.travis/run.inc.sh
+++ b/.travis/run.inc.sh
@@ -6,14 +6,14 @@ if [ -z "$PLATFORMS" ]; then
 		PLATFORMS=$(ls targets/ | grep -v ".py" | grep -v "common" | grep -v "$SKIP_PLATFORMS" | sed -e"s+targets/++")
 	else
 		PLATFORMS="$PLATFORM"
+		unset PLATFORM
 	fi
 fi
 echo "Running with PLATFORMS='$PLATFORMS'"
 
 if [ -z "$CPUS" ]; then
 	if [ -z "$CPU" ]; then
-		#CPUS="lm32 or1k riscv32"
-		CPUS="lm32 or1k"
+		CPUS="lm32 or1k picorv32 vexriscv"
 	else
 		CPUS="$CPU"
 		unset CPU

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -7,21 +7,36 @@ set -e
 ./.travis/fixup-git.sh
 
 function setup() {
-	export FULL_PLATFORM=$1
-	export TARGET=$2
-	export FULL_CPU=$3
+	SPLIT_REGEX="^\([^.]*\)\.\?\(.*\)\$"
 
-	if [ x$4 != x ]; then
-		FIRMWARE=$4
-	else
-		unset $FIRMWARE
-	fi
-
-	if [ -z "$FULL_PLATFORM" -o -z "$TARGET" -o -z "$FULL_CPU" ]; then
+	if [ -z "$1" -o -z "$2" -o -z "$3" ]; then
 		echo "usage: setup FULL_PLATFORM TARGET FULL_CPU FIRMWARE"
-		echo "  got: setup '$FULL_PLATFORM' '$TARGET' '$FULL_CPU' '$FIRMWARE'"
+		echo "  got: setup '$1' '$2' '$3' '$4'"
 		return 1
 	fi
+
+	#export FULL_PLATFORM=$1
+	export PLATFORM="$(echo $1 | sed -e"s/$SPLIT_REGEX/\1/")"
+	export PLATFORM_EXPANSION="$(echo $1 | sed -e"s/$SPLIT_REGEX/\2/")"
+
+	export TARGET="$2"
+
+	#export FULL_CPU=$3
+	export CPU="$(echo $3 | sed -e"s/$SPLIT_REGEX/\1/")"
+	export CPU_VARIANT="$(echo $3 | sed -e"s/$SPLIT_REGEX/\2/")"
+
+	if [ x$4 != x ]; then
+		FIRMWARE="$4"
+	else
+		unset FIRMWARE
+	fi
+
+	echo "--"
+	echo "PLATFORM=$PLATFORM PLATFORM_EXPANSION=$PLATFORM_EXPANSION"
+	echo "TARGET=$TARGET"
+	echo "CPU=$CPU CPU_VARIANT=$CPU_VARIANT"
+	echo "FIRMWARE=$FIRMWARE"
+	echo "--"
 
 	DF_BEFORE_DOWNLOAD="$(($(stat -f --format="%a*%S" .)))"
 	(

--- a/Makefile
+++ b/Makefile
@@ -496,7 +496,7 @@ help:
 	@echo "                        (current: $(TARGET), default: $(DEFAULT_TARGET))"
 	@echo ""
 	@echo " CPU describes which soft-CPU to use on the FPGA."
-	@echo " CPU=lm32 OR or1k"
+	@echo " CPU=lm32 OR or1k OR picorv32 OR vexriscv"
 	@echo "                        (current: $(CPU), default: $(DEFAULT_CPU))"
 	@echo ""
 	@echo " CPU_VARIANT describes which soft-CPU variant to use on the FPGA."

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -102,6 +102,9 @@ firmware.elf: $(FIRMWARE_DIRECTORY)/$(LINKER_LD) $(OBJECTS)
 boot-helper-$(CPU).S: $(BIOS_DIRECTORY)/boot-helper-$(CPU).S
 	cp $< $@
 
+boot-helper-$(CPU).o: boot-helper-$(CPU).S
+	$(assemble)
+
 %.o: $(FIRMWARE_DIRECTORY)/%.c
 	$(compile)
 

--- a/firmware/stub/Makefile
+++ b/firmware/stub/Makefile
@@ -50,6 +50,9 @@ firmware.elf: $(STUB_DIRECTORY)/$(LINKER_LD) $(OBJECTS)
 boot-helper-$(CPU).S: $(BIOS_DIRECTORY)/boot-helper-$(CPU).S
 	cp $< $@
 
+boot-helper-$(CPU).o: boot-helper-$(CPU).S
+	$(assemble)
+
 %.o: $(STUB_DIRECTORY)/%.c
 	$(compile)
 

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -55,11 +55,11 @@ fi
 # Get linux-litex is needed
 LINUX_SRC="$TOP_DIR/third_party/linux"
 LINUX_LOCAL="$LINUX_GITLOCAL" # Local place to clone from
-LINUX_REMOTE="${LINUX_REMOTE:-https://github.com/mithro/linux-litex.git}"
-LINUX_REMOTE_NAME=mithro-linux-litex
+LINUX_REMOTE="${LINUX_REMOTE:-https://github.com/timvideos/linux-litex.git}"
+LINUX_REMOTE_NAME=timvideos-linux-litex
 LINUX_REMOTE_BIT=$(echo $LINUX_REMOTE | sed -e's-^.*://--' -e's/.git$//')
 LINUX_CLONE_FROM="${LINUX_LOCAL:-$LINUX_REMOTE}"
-LINUX_BRANCH=${LINUX_BRANCH:-litex-minimal}
+LINUX_BRANCH=${LINUX_BRANCH:-master}
 (
 	# Download the Linux source for the first time
 	if [ ! -d "$LINUX_SRC" ]; then
@@ -93,9 +93,9 @@ LINUX_BRANCH=${LINUX_BRANCH:-litex-minimal}
 
 # Get litex-devicetree
 LITEX_DT_SRC="$TOP_DIR/third_party/litex-devicetree"
-LITEX_DT_REMOTE="${LITEX_DT_REMOTE:-https://github.com/mithro/litex-devicetree.git}"
+LITEX_DT_REMOTE="${LITEX_DT_REMOTE:-https://github.com/timvideos/litex-devicetree.git}"
 LITEX_DT_REMOTE_BIT=$(echo $LITEX_DT_REMOTE | sed -e's-^.*://--' -e's/.git$//')
-LITEX_DT_REMOTE_NAME=mithro-litex-devicetree
+LITEX_DT_REMOTE_NAME=timvideos-litex-devicetree
 LITEX_DT_BRANCH=master
 (
 	# Download the Linux source for the first time

--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -328,7 +328,7 @@ echo "---------------------------------------"
 if [ "$CPU" = "lm32" -o "$CPU" = "or1k" ]; then
 	CPU_ARCH=$CPU
 elif [ "$CPU" = "vexriscv" -o "$CPU" = "picorv32" ]; then
-	CPU_ARCH=riscv32-unknown
+	CPU_ARCH=riscv32
 fi
 
 # binutils for the target

--- a/scripts/enter-env.sh
+++ b/scripts/enter-env.sh
@@ -315,7 +315,7 @@ echo "---------------------------------------"
 if [ "$CPU" = "lm32" -o "$CPU" = "or1k" ]; then
 	CPU_ARCH=$CPU
 elif [ "$CPU" = "vexriscv" -o "$CPU" = "picorv32" ]; then
-	CPU_ARCH=riscv32-unknown
+	CPU_ARCH=riscv32
 fi
 
 # binutils for the target

--- a/scripts/settings.sh
+++ b/scripts/settings.sh
@@ -11,7 +11,11 @@ HEXFILE_VERSION=0.1
 
 # Conda package versions
 BINUTILS_VERSION=2.31.1
+if [ "$CPU" != "or1k" ]; then
+GCC_VERSION=8.2.0
+else
 GCC_VERSION=5.4.0
+fi
 SDCC_VERSION=3.5.0
 OPENOCD_VERSION=0.10.0
 

--- a/targets/arty/net.py
+++ b/targets/arty/net.py
@@ -27,7 +27,7 @@ class NetSoC(BaseSoC):
 
     def __init__(self, platform, *args, **kwargs):
         # Need a larger integrated ROM on or1k to fit the BIOS with TFTP support.
-        if 'integrated_rom_size' not in kwargs and kwargs.get('cpu_type', 'lm32') == 'or1k':
+        if 'integrated_rom_size' not in kwargs and kwargs.get('cpu_type', 'lm32') != 'lm32':
             kwargs['integrated_rom_size'] = 0x10000
 
         BaseSoC.__init__(self, platform, *args, **kwargs)

--- a/targets/atlys/net.py
+++ b/targets/atlys/net.py
@@ -26,7 +26,7 @@ class NetSoC(BaseSoC):
 
     def __init__(self, platform, *args, **kwargs):
         # Need a larger integrated ROM on or1k to fit the BIOS with TFTP support.
-        if 'integrated_rom_size' not in kwargs and kwargs.get('cpu_type', 'lm32') == 'or1k':
+        if 'integrated_rom_size' not in kwargs and kwargs.get('cpu_type', 'lm32') != 'lm32':
             kwargs['integrated_rom_size'] = 0x10000
 
         BaseSoC.__init__(self, platform, *args, **kwargs)

--- a/targets/nexys_video/net.py
+++ b/targets/nexys_video/net.py
@@ -27,7 +27,7 @@ class NetSoC(BaseSoC):
 
     def __init__(self, platform, *args, **kwargs):
         # Need a larger integrated ROM on or1k to fit the BIOS with TFTP support.
-        if 'integrated_rom_size' not in kwargs and kwargs.get('cpu_type', 'lm32') == 'or1k':
+        if 'integrated_rom_size' not in kwargs and kwargs.get('cpu_type', 'lm32') != 'lm32':
             kwargs['integrated_rom_size'] = 0x10000
 
         BaseSoC.__init__(self, platform, *args, **kwargs)

--- a/targets/opsis/base.py
+++ b/targets/opsis/base.py
@@ -237,7 +237,7 @@ class BaseSoC(SoCSDRAM):
         if 'integrated_rom_size' not in kwargs:
             kwargs['integrated_rom_size']=0x8000
         if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x4000
+            kwargs['integrated_sram_size']=0x8000
 
         clk_freq = 50*1000000
 

--- a/targets/opsis/net.py
+++ b/targets/opsis/net.py
@@ -28,7 +28,7 @@ class NetSoC(BaseSoC):
 
     def __init__(self, platform, *args, **kwargs):
         # Need a larger integrated ROM on or1k to fit the BIOS with TFTP support.
-        if 'integrated_rom_size' not in kwargs and kwargs.get('cpu_type', 'lm32') == 'or1k':
+        if 'integrated_rom_size' not in kwargs and kwargs.get('cpu_type', 'lm32') != 'lm32':
             kwargs['integrated_rom_size'] = 0x10000
 
         BaseSoC.__init__(self, platform, *args, **kwargs)

--- a/targets/sim/net.py
+++ b/targets/sim/net.py
@@ -33,7 +33,7 @@ class NetSoC(BaseSoC):
 
     def __init__(self, *args, **kwargs):
         # Need a larger integrated ROM on or1k to fit the BIOS with TFTP support.
-        if 'integrated_rom_size' not in kwargs and kwargs.get('cpu_type', 'lm32') == 'or1k':
+        if 'integrated_rom_size' not in kwargs and kwargs.get('cpu_type', 'lm32') != 'lm32':
             kwargs['integrated_rom_size'] = 0x10000
 
         BaseSoC.__init__(self, *args, **kwargs)


### PR DESCRIPTION
Currently or1k is stuff on 5.4.0, but the lm32 and riscv32 should both
work with gcc 8.2.0