### PR TITLE
Install tinyprog from repo until new version is uploaded to PyPI.

### DIFF
--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -285,7 +285,7 @@ fi
 if [ "$PLATFORM" = "tinyfpga_bx" ]; then
 	echo
 	echo "Installing tinyprog (tool for TinyFPGA BX boards)"
-	pip install tinyprog
+	pip install "git+https://github.com/tinyfpga/TinyFPGA-Bootloader#egg=tinyprog&subdirectory=programmer&subdirectory=programmer"
 	check_exists tinyprog
 fi
 


### PR DESCRIPTION
Self-explanatory, according to [pip docs](https://pip.readthedocs.io/en/stable/reference/pip_install/#vcs-support), this is the correct way to use pip to install directly from a repository.

Tested locally on my machine and it worked just fine.