### PR TITLE
scripts: Add build-zephyr.sh script.

### DIFF
--- a/scripts/build-zephyr.sh
+++ b/scripts/build-zephyr.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+if [ "`whoami`" = "root" ]
+then
+	echo "Running the script as root is not permitted"
+	exit 1
+fi
+
+CALLED=$_
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] && SOURCED=1 || SOURCED=0
+
+SCRIPT_SRC=$(realpath ${BASH_SOURCE[0]})
+SCRIPT_DIR=$(dirname $SCRIPT_SRC)
+TOP_DIR=$(realpath $SCRIPT_DIR/..)
+
+if [ $SOURCED = 1 ]; then
+	echo "You must run this script, rather then try to source it."
+	echo "$SCRIPT_SRC"
+	exit 1
+fi
+
+if [ -z "$HDMI2USB_ENV" ]; then
+	echo "You appear to not be inside the HDMI2USB environment."
+	echo "Please enter environment with:"
+	echo "  source scripts/enter-env.sh"
+	exit 1
+fi
+
+# Imports TARGET, PLATFORM, CPU and TARGET_BUILD_DIR from Makefile
+eval $(make env)
+make info
+
+source $SCRIPT_DIR/settings.sh
+
+# local version of SDK has a higher priority as it might contain a newer SDK
+SDK_LOCAL_LOCATION="$BUILD_DIR/zephyr_sdk"
+if [ -d "$SDK_LOCAL_LOCATION" ]; then
+	export ZEPHYR_SDK_INSTALL_DIR="$SDK_LOCAL_LOCATION"
+elif [ -z "$ZEPHYR_SDK_INSTALL_DIR" ]; then
+	echo "Zephyr SDK not found"
+	echo "Did you forget to run scripts/download-env.sh?"
+	exit 1
+fi
+
+export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+echo "Using Zephyr SDK from: $ZEPHYR_SDK_INSTALL_DIR"
+
+set -x
+set -e
+
+ZEPHYR_REPO=https://github.com/zephyrproject-rtos/zephyr
+ZEPHYR_REPO_BRANCH=master
+
+case $CPU in
+	vexriscv)
+		case "$CPU_VARIANT" in
+			lite* | standard* | full* | linux*)
+				TARGET_BOARD=arty_litex_vexriscv
+				ZEPHYR_REPO=https://github.com/antmicro/zephyr
+				ZEPHYR_REPO_BRANCH=litex-vexriscv
+				;;
+			*)
+				echo "Zephyr needs a CPU_VARIANT set to at least 'lite' for the support of 'ecall' instruction."
+				echo "Supported variants: lite, lite+debug, standard, standard+debug, full, full+debug, linux."
+				echo "Currently selected variant: $CPU_VARIANT"
+				exit 1
+				;;
+		esac
+		;;
+	*)
+		echo "CPU $CPU isn't supported at the moment."
+		exit 1
+		;;
+esac
+
+if [ "$FIRMWARE" != "zephyr" ]; then
+	echo "When building Zephyr you should set FIRMWARE to 'zephyr'."
+	exit 1
+fi
+
+ZEPHYR_SRC_DIR=$THIRD_DIR/zephyr
+ZEPHYR_APP=${ZEPHYR_APP:-subsys/shell/shell_module}
+OUTPUT_DIR=$TOP_DIR/$TARGET_BUILD_DIR/software/zephyr
+export ZEPHYR_BASE=$ZEPHYR_SRC_DIR/zephyr
+
+if [ ! -d "$ZEPHYR_SRC_DIR" ]; then
+	mkdir -p $ZEPHYR_SRC_DIR
+	cd $ZEPHYR_SRC_DIR
+	west init --manifest-url $ZEPHYR_REPO --manifest-rev $ZEPHYR_REPO_BRANCH
+fi
+west build -b $TARGET_BOARD $ZEPHYR_SRC_DIR/zephyr/samples/$ZEPHYR_APP --build-dir $OUTPUT_DIR
+
+cd $OUTPUT_DIR
+if [ ! -f "firmware.bin" ]; then
+	ln -s zephyr/zephyr.bin firmware.bin
+fi
+

--- a/scripts/enter-env.sh
+++ b/scripts/enter-env.sh
@@ -344,6 +344,28 @@ check_version ${CPU_ARCH}-elf-gcc $GCC_VERSION || return 1
 #
 #check_version ${CPU_ARCH}-elf-gdb $GDB_VERSION
 
+# Zephyr SDK
+################################################
+if [ "$FIRMWARE" = "zephyr" ]; then
+	SCRIPT_NAME="zephyr-sdk-$ZEPHYR_SDK_VERSION-setup.run"
+	LOCAL_LOCATION="$BUILD_DIR/zephyr_sdk"
+
+	DETECTED_SDK_LOCATION=""
+	for DIR in "$LOCAL_LOCATION" "$ZEPHYR_SDK_INSTALL_DIR"; do
+		if [ -d "$DIR" ]; then
+			cat "$DIR/sdk_version" | grep -q $ZEPHYR_SDK_VERSION && DETECTED_SDK_LOCATION="$DIR"
+		fi
+	done
+
+	echo
+	if [ -d "$DETECTED_SDK_LOCATION" ]; then
+		echo "Zephyr SDK $ZEPHYR_SDK_VERSION found in: $DETECTED_SDK_LOCATION"
+
+	else
+		echo "Zephyr SDK not found. Please run download-env.sh"
+		return 1
+	fi
+fi
 
 # Python modules
 ################################################
@@ -385,6 +407,24 @@ check_import_version hexfile $HEXFILE_VERSION || return 1
 
 
 check_import_version hdmi2usb.modeswitch $HDMI2USB_MODESWITCH_VERSION || return 1
+
+if [ "$FIRMWARE" = "zephyr" ]; then
+	# yaml for parsing configuration in Zephyr SDK
+
+
+
+	check_import yaml || return 1
+
+	# elftools for Zephyr SDK
+
+
+	check_import elftools || return 1
+
+	# west tool for building Zephyr
+
+
+	check_import west || return 1
+fi
 
 # git commands
 echo ""

--- a/scripts/settings.sh
+++ b/scripts/settings.sh
@@ -15,6 +15,9 @@ GCC_VERSION=8.2.0
 SDCC_VERSION=3.5.0
 OPENOCD_VERSION=0.10.0
 
+# Other tools versions
+ZEPHYR_SDK_VERSION=0.10.0
+
 # lite modules
 LITE_REPOS="
 	migen


### PR DESCRIPTION
This adds a script for building Zephyr RTOS for VexRiscv as a firmware for LiteX Buildenv.