### PR TITLE
zephyr: Change LiteX+VexRiscv board name

### DIFF
--- a/scripts/build-zephyr.sh
+++ b/scripts/build-zephyr.sh
@@ -55,7 +55,7 @@ case $CPU in
 	vexriscv)
 		case "$CPU_VARIANT" in
 			lite* | standard* | full* | linux*)
-				TARGET_BOARD=arty_litex_vexriscv
+				TARGET_BOARD=litex_vexriscv
 				ZEPHYR_REPO=https://github.com/antmicro/zephyr
 				ZEPHYR_REPO_BRANCH=litex-vexriscv
 				;;


### PR DESCRIPTION
In the PR I changed the board name from `arty_litex_vexriscv` to `litex_vexriscv`. Without this fix, the script will fail when building Zephyr.