### PR TITLE
Make default platform an open source one (tinyfpga_bx)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ export PYTHON
 SPLIT_REGEX := ^\([^.]*\)\.\?\(.*\)$$
 
 # The platform to run on. It is made up of FPGA_MAIN_BOARD.EXPANSION_BOARD
-DEFAULT_PLATFORM = opsis
+DEFAULT_PLATFORM = tinyfpga_bx
 DEFAULT_PLATFORM_EXPANSION =
 
 ifneq ($(FULL_PLATFORM),)
@@ -80,7 +80,18 @@ ifneq ($(FULL_CPU),)
     endif
 endif
 
+# On our default platform, and CPU, we need a minimal CPU variation to fit,
+# so we default the variant to minimal on the default platform; on any other
+# platform we default to the standard CPU.  We want this to end up in
+# the prompt, so we do not set it as the DEFAULT_CPU_VARIANT, but apply
+# it later.
+#
 CPU ?= $(DEFAULT_CPU)
+ifeq ($(PLATFORM),$(DEFAULT_PLATFORM))
+  ifeq ($(CPU),$(DEFAULT_CPU))
+CPU_VARIANT ?= minimal
+  endif
+endif
 CPU_VARIANT ?= $(DEFAULT_CPU_VARIANT)
 
 ifeq ($(CPU),)
@@ -119,9 +130,10 @@ ifeq ($(TARGET),)
 endif
 export TARGET
 
-FIRMWARE ?= firmware
+DEFAULT_FIRMWARE ?= firmware
+FIRMWARE ?= $(DEFAULT_FIRMWARE)
 ifeq ($(FIRMWARE),)
-    FIRMWARE = firmware
+    FIRMWARE = $(DEFAULT_FIRMWARE)
 endif
 export FIRMWARE
 
@@ -437,6 +449,7 @@ env:
 	@echo "export CPU='$(CPU)'"
 	@echo "export CPU_VARIANT='$(CPU_VARIANT)'"
 	@echo "export FIRMWARE='$(FIRMWARE)'"
+	@echo "export DEFAULT_FIRMWARE='$(DEFAULT_FIRMWARE)'"
 	@echo "export OVERRIDE_FIRMWARE='$(OVERRIDE_FIRMWARE)'"
 	@echo "export PROG='$(PROG)'"
 	@echo "export TARGET_BUILD_DIR='$(TARGET_BUILD_DIR)'"
@@ -463,7 +476,7 @@ info:
 	@echo "                Target: $(TARGET) (default: $(DEFAULT_TARGET))"
 	@echo "                   CPU: $(FULL_CPU) (default: $(DEFAULT_CPU))"
 	@if [ x"$(FIRMWARE)" != x"firmware" ]; then \
-		echo "               Firmare: $(FIRMWARE) (default: firmware)"; \
+		echo "              Firmware: $(FIRMWARE) (default: $(DEFAULT_FIRMWARE))"; \
 	fi
 
 prompt:

--- a/Makefile
+++ b/Makefile
@@ -85,18 +85,7 @@ ifneq ($(FULL_CPU),)
     endif
 endif
 
-# On our default platform, and CPU, we need a minimal CPU variation to fit,
-# so we default the variant to minimal on the default platform; on any other
-# platform we default to the standard CPU.  We want this to end up in
-# the prompt, so we do not set it as the DEFAULT_CPU_VARIANT, but apply
-# it later.
-#
 CPU ?= $(DEFAULT_CPU)
-ifeq ($(PLATFORM),$(DEFAULT_PLATFORM))
-  ifeq ($(CPU),$(DEFAULT_CPU))
-CPU_VARIANT ?= minimal
-  endif
-endif
 CPU_VARIANT ?= $(DEFAULT_CPU_VARIANT)
 
 ifeq ($(CPU),)

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ export PYTHON
 SPLIT_REGEX := ^\([^.]*\)\.\?\(.*\)$$
 
 # The platform to run on. It is made up of FPGA_MAIN_BOARD.EXPANSION_BOARD
+#
+# 2019-05-15 - Default platform is tinyfpga_bx as it is widely available
+#              and has open source tooling; change to icebreaker later in 2019
+# FIXME:       (See https://github.com/timvideos/litex-buildenv/issues/134)
+#
 DEFAULT_PLATFORM = tinyfpga_bx
 DEFAULT_PLATFORM_EXPANSION =
 

--- a/targets/tinyfpga_bx/Makefile.mk
+++ b/targets/tinyfpga_bx/Makefile.mk
@@ -7,6 +7,8 @@ endif
 # Settings
 DEFAULT_TARGET = base
 TARGET ?= $(DEFAULT_TARGET)
+DEFAULT_FIRMWARE = micropython
+FIRMWARE ?= $(DEFAULT_FIRMWARE)
 BAUD ?= 115200
 
 # Image

--- a/targets/tinyfpga_bx/Makefile.mk
+++ b/targets/tinyfpga_bx/Makefile.mk
@@ -11,6 +11,21 @@ DEFAULT_FIRMWARE = micropython
 FIRMWARE ?= $(DEFAULT_FIRMWARE)
 BAUD ?= 115200
 
+# Default to minimal CPU variant on TinyFPGA BX for space reasons, unless
+# it is explicitly set to something else (and if we change it, we need to
+# reset FULL_CPU for conssitency); at the time that we are evaluated,
+# CPU_VARIANT has already been explicitly set to an empty string so ?=
+# cannot be used.
+#
+ifeq ($(CPU),lm32)
+  ifeq ($(CPU_VARIANT),)
+CPU_VARIANT = minimal
+  endif
+  ifneq ($(CPU_VARIANT),)
+FULL_CPU = $(CPU).$(CPU_VARIANT)
+  endif
+endif
+
 # Image
 image-flash-$(PLATFORM):
 	tinyprog --program-image $(IMAGE_FILE)


### PR DESCRIPTION
Historically the default platform litex-buildenv was the "opsis" video board, because of the origins of litex-buildenv in the HDMI2USB project.  However the opsis requires Xilinx tools installed, which require non-trivial manual steps.  Ease the path for naive users by defaulting to a target that has all open source tooling, so that we can install all tools easily, and thus the user will either quickly reach a useful point, or quickly and painlessly reach a dead end and realise they should set some environment variables.

```
. scripts/enter-env.sh
```
gives `LX P=tinyfpga_bx.minimal F=micropython`

```
export PLATFORM=opsis
. scripts/enter-env.sh
```
gives `LX P=opsis`, as before.

(fixes timvideos/litex-buildenv#134)

Examples:

```
ewen@parthenon:~$ cd /src/fpga/litex-buildenv/
ewen@parthenon:/src/fpga/litex-buildenv$ . scripts/enter-env.sh 
[...]
(LX P=tinyfpga_bx.minimal F=micropython R=default-target-tinyfpga-bx) ewen@parthenon:/src/fpga/litex-buildenv$ make info
              Platform: tinyfpga_bx
                Target: base (default: base)
                   CPU: lm32.minimal (default: lm32)
              Firmware: micropython (default: micropython)
(LX P=tinyfpga_bx.minimal F=micropython R=default-target-tinyfpga-bx) ewen@parthenon:/src/fpga/litex-buildenv$ 
```

```
ewen@parthenon:~$ cd /src/fpga/litex-buildenv/
ewen@parthenon:/src/fpga/litex-buildenv$ export PLATFORM=opsis
ewen@parthenon:/src/fpga/litex-buildenv$ . scripts/enter-env.sh 
[...]
(LX P=opsis R=default-target-tinyfpga-bx) ewen@parthenon:/src/fpga/litex-buildenv$ make info
              Platform: opsis
                Target: video (default: video)
                   CPU: lm32 (default: lm32)
(LX P=opsis R=default-target-tinyfpga-bx) ewen@parthenon:/src/fpga/litex-buildenv$ 
```
```