### PR TITLE
scripts: switch to portable Renode release

### DIFF
--- a/scripts/build-renode.sh
+++ b/scripts/build-renode.sh
@@ -17,21 +17,20 @@ RENODE_BIN=${RENODE_BIN:-renode}
 if ! command -v $RENODE_BIN 2>&1 1>/dev/null; then
 	# Download prebuilt renode Release if none is currently installed
 
-	RENODE_PACKAGE=renode-latest.pkg.tar.xz
+	RENODE_PACKAGE=renode-latest.linux-portable.tar.gz
 	RENODE_URL=https://antmicro.com/projects/renode/builds/$RENODE_PACKAGE
 	RENODE_LOCATION="$BUILD_DIR/renode"
-	RENODE_BIN=$RENODE_LOCATION/opt/renode/bin/Renode.exe
+	mkdir -p $RENODE_LOCATION
 
-	if [ ! -x $RENODE_BIN ]; then
-		mkdir -p $RENODE_LOCATION
+	RENODE_BIN=`find $RENODE_LOCATION -executable -type f -name renode`
+	if [ ! -x "$RENODE_BIN" ]; then
 		(
 			cd $RENODE_LOCATION
 			wget $RENODE_URL
 			tar -xf $RENODE_PACKAGE
 		)
-		
-		chmod u+x $RENODE_BIN
-		echo "Renode downloaded and installed locally: $RENODE_BIN" 
+		RENODE_BIN=`find $RENODE_LOCATION -executable -type f -name renode`
+		echo "Renode downloaded and installed locally: $RENODE_BIN"
 	fi
 fi
 


### PR DESCRIPTION
This eliminates the requirement of mono environment
installed in the system.