### PR TITLE
scripts: fix running portable Renode

### DIFF
--- a/scripts/build-renode.sh
+++ b/scripts/build-renode.sh
@@ -40,6 +40,7 @@ if ! $RENODE_FOUND; then
 			tar -xf $RENODE_PACKAGE
 		)
 
+		RENODE_BIN=`find $RENODE_LOCATION -executable -type f -name renode`
 		chmod u+x $RENODE_BIN
 		echo "Renode downloaded and installed locally: $RENODE_BIN"
 	fi


### PR DESCRIPTION
Without this fix, `RENODE_BIN` is empty and the script fails.