### PR TITLE
Better vexriscv linux support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,6 +129,8 @@ env:
    - C=mor1kx.linux     TC="ise"       P=atlys             T="net"        F=linux
    - C=mor1kx.linux     TC="ise"       P=opsis             T="net"        F=linux
    # FIXME: Add vexriscv.linux
+   - C=vexriscv.linux   TC="vivado"    P=arty              T="net"        F=linux
+   - C=vexriscv.linux   TC="ise"       P=opsis             T="net"        F=linux
    # FIXME: Add rocket.linux
    #--------------------------------------------
    # Zephyr Targets

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,8 @@ TARGET_BUILD_DIR = build/$(FULL_PLATFORM)_$(TARGET)_$(FULL_CPU)/
 
 GATEWARE_FILEBASE = $(TARGET_BUILD_DIR)/gateware/top
 BIOS_FILE = $(TARGET_BUILD_DIR)/software/bios/bios.bin
-FIRMWARE_FILEBASE = $(TARGET_BUILD_DIR)/software/$(FIRMWARE)/firmware
+FIRMWARE_DIR = $(TARGET_BUILD_DIR)/software/$(FIRMWARE)
+FIRMWARE_FILEBASE = $(FIRMWARE_DIR)/firmware
 IMAGE_FILE = $(TARGET_BUILD_DIR)/image-gateware+bios+$(FIRMWARE).bin
 
 TFTP_IPRANGE ?= 192.168.100
@@ -381,8 +382,18 @@ IN_TFTPD:=/usr/sbin/in.tftpd
 endif
 
 tftp: $(FIRMWARE_FILEBASE).bin
+	rm -rf $(TFTPD_DIR)
 	mkdir -p $(TFTPD_DIR)
+ifeq ($(FIRMWARE),linux)
+	cp $(FIRMWARE_FILEBASE).bin $(TFTPD_DIR)/Image
+	cp $(FIRMWARE_DIR)/$(CPU_ARCH)-rootfs.cpio $(TFTPD_DIR)/rootfs.cpio
+ifeq ($(CPU),vexriscv)
+	cp $(FIRMWARE_DIR)/rv32.dtb $(TFTPD_DIR)
+	cp $(TARGET_BUILD_DIR)/emulator/emulator.bin $(TFTPD_DIR)
+endif
+else
 	cp $(FIRMWARE_FILEBASE).bin $(TFTPD_DIR)/boot.bin
+endif
 
 tftpd_stop:
 	# FIXME: This is dangerous...


### PR DESCRIPTION
This PR updates submodules with the newest version of:

* `VexRiscv` supporting building emulator (BIOS) for LiteX target,
* `LiteX` 
    * with the fixed netboot/flashboot for VexRiscv.linux cpu,
    * with cpu variant information generated to `csr.csv`,
* `litex-renode` with the enhancements in script generating Renode platform utilizing new information in `csr.csv` and supporting more peripherals

It also adds generation of `emulator_ram` to arty target when building for `VexRiscv.linux` cpu. This is a memory where VexRiscv emulator is loaded by the LiteX BIOS.

**EDIT**: I split this PR into 3 separate ones. This one contains now changes related to building Linux for VexRiscv using `./scripts/build-linux.sh` script.