### PR TITLE
Fix endianness

### DIFF
--- a/firmware/uip/contiki-conf.h
+++ b/firmware/uip/contiki-conf.h
@@ -27,7 +27,12 @@ typedef unsigned int uip_stats_t;
 #endif
 
 /* uIP configuration */
+#if defined(__lm32__) || defined(__or1k__)
 #define UIP_CONF_BYTE_ORDER	UIP_BIG_ENDIAN
+#else
+#define UIP_CONF_BYTE_ORDER	UIP_LITTLE_ENDIAN
+#endif
+
 #define UIP_CONF_LLH_LEN	14
 #define UIP_CONF_BROADCAST	1
 #define UIP_CONF_LOGGING	1

--- a/targets/arty/net.py
+++ b/targets/arty/net.py
@@ -31,7 +31,7 @@ class NetSoC(BaseSoC):
             platform.request("eth_clocks"),
             platform.request("eth"))
         self.submodules.ethmac = LiteEthMAC(
-            phy=self.ethphy, dw=32, interface="wishbone")
+            phy=self.ethphy, dw=32, interface="wishbone", endianness=self.cpu.endianness)
         self.add_wb_slave(mem_decoder(self.mem_map["ethmac"]), self.ethmac.bus)
         self.add_memory_region("ethmac",
             self.mem_map["ethmac"] | self.shadow_base, 0x2000)

--- a/targets/atlys/net.py
+++ b/targets/atlys/net.py
@@ -32,7 +32,7 @@ class NetSoC(BaseSoC):
             self.clk_freq)
 
         self.submodules.ethmac = LiteEthMAC(
-            phy=self.ethphy, dw=32, interface="wishbone")
+            phy=self.ethphy, dw=32, interface="wishbone", endianness=self.cpu.endianness)
         self.add_wb_slave(mem_decoder(self.mem_map["ethmac"]), self.ethmac.bus)
         self.add_memory_region("ethmac",
             self.mem_map["ethmac"] | self.shadow_base, 0x2000)

--- a/targets/mimas_a7/net.py
+++ b/targets/mimas_a7/net.py
@@ -27,7 +27,7 @@ class NetSoC(BaseSoC):
             platform.request("eth_clocks"),
             platform.request("eth"))
         self.submodules.ethmac = LiteEthMAC(
-            phy=self.ethphy, dw=32, interface="wishbone")
+            phy=self.ethphy, dw=32, interface="wishbone", endianness=self.cpu.endianness)
         self.add_wb_slave(mem_decoder(self.mem_map["ethmac"]), self.ethmac.bus)
         self.add_memory_region("ethmac",
             self.mem_map["ethmac"] | self.shadow_base, 0x2000)

--- a/targets/nexys_video/net.py
+++ b/targets/nexys_video/net.py
@@ -31,7 +31,7 @@ class NetSoC(BaseSoC):
             platform.request("eth_clocks"),
             platform.request("eth"))
         self.submodules.ethmac = LiteEthMAC(
-            phy=self.ethphy, dw=32, interface="wishbone")
+            phy=self.ethphy, dw=32, interface="wishbone", endianness=self.cpu.endianness)
         self.add_wb_slave(mem_decoder(self.mem_map["ethmac"]), self.ethmac.bus)
         self.add_memory_region("ethmac",
             self.mem_map["ethmac"] | self.shadow_base, 0x2000)

--- a/targets/opsis/net.py
+++ b/targets/opsis/net.py
@@ -33,7 +33,7 @@ class NetSoC(BaseSoC):
             platform.request("eth"))
         self.platform.add_source("gateware/rgmii_if.vhd")
         self.submodules.ethmac = LiteEthMAC(
-            phy=self.ethphy, dw=32, interface="wishbone")
+            phy=self.ethphy, dw=32, interface="wishbone", endianness=self.cpu.endianness)
         self.add_wb_slave(mem_decoder(self.mem_map["ethmac"]), self.ethmac.bus)
         self.add_memory_region("ethmac",
             self.mem_map["ethmac"] | self.shadow_base, 0x2000)

--- a/targets/sim/net.py
+++ b/targets/sim/net.py
@@ -34,7 +34,7 @@ class NetSoC(BaseSoC):
         BaseSoC.__init__(self, *args, **kwargs)
 
         self.submodules.ethphy = LiteEthPHYModel(self.platform.request("eth"))
-        self.submodules.ethmac = LiteEthMAC(phy=self.ethphy, dw=32, interface="wishbone")
+        self.submodules.ethmac = LiteEthMAC(phy=self.ethphy, dw=32, interface="wishbone", endianness=self.cpu.endianness)
         self.add_wb_slave(mem_decoder(self.mem_map["ethmac"]), self.ethmac.bus)
         self.add_memory_region("ethmac", self.mem_map["ethmac"] | self.shadow_base, 0x2000)
 


### PR DESCRIPTION
This PR fixes two problems with endianness for little endian CPUs (like VexRiscv):

* liteeth was configured to big endian and it was not possible to netboot in LiteX bios on VexRiscv,
* uip was configured to big endian and it was not possible to telnet into the firmware on VexRiscv.
