### PR TITLE
Exclude glusterfs from qemu build

### DIFF
--- a/scripts/build-qemu.sh
+++ b/scripts/build-qemu.sh
@@ -85,10 +85,11 @@ if [ ! -f "$TARGET_QEMU_BUILD_DIR/Makefile" ]; then
 			--enable-fdt \
 			--disable-kvm \
 			--disable-xen \
+			--disable-glusterfs \
 			--enable-debug \
 			--enable-debug-info
 
-		ln -s $(realpath $PWD/../software/include/generated) generated
+		ln -sf $(realpath $PWD/../software/include/generated) generated
 	)
 fi
 


### PR DESCRIPTION
Resolve a compile error on Debian Sid.

GCC - 8.3.0-19
libglusterfs - 6.4-2
```
error e.g.
/home/daves/github/litex-buildenv/third_party/qemu-litex/block/gluster.c:1038:13: error: too few arguments to function ‘glfs_ftruncate’
         if (glfs_ftruncate(fd, offset)) {
```