### PR TITLE
iceFUN board

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ env:
    - C=lm32.lite        TC="icestorm"  P=icebreaker        T="base"       F=stub
    - C=lm32.lite        TC="icestorm"  P=tinyfpga_bx       T="base"       F=stub
    - C=lm32.lite        TC="icestorm"  P=upduino_v1        T="base"       F=stub
+   - C=lm32.lite        TC="icestorm"  P=icefun            T="base"       F=stub
    - C=lm32.lite        TC="vivado"    P=arty              T="base net"
    - C=lm32.lite                       P=opsis             T="base net"
    - C=lm32.minimal     TC="icestorm"  P=ice40_hx8k_b_evn  T="base"       F=stub
@@ -70,6 +71,7 @@ env:
    - C=lm32.minimal     TC="icestorm"  P=icebreaker        T="base"       F=stub
    - C=lm32.minimal     TC="icestorm"  P=tinyfpga_bx       T="base"       F=stub
    - C=lm32.minimal     TC="icestorm"  P=upduino_v1        T="base"       F=stub
+   - C=lm32.minimal     TC="icestorm"  P=icefun            T="base"       F=stub
    - C=lm32.minimal     TC="vivado"    P=arty              T="base net"
    - C=lm32.minimal     TC="ise"       P=opsis             T="base net"
    # OpenRISC1000
@@ -89,6 +91,7 @@ env:
    - C=vexriscv.lite    TC="icestorm"  P=icebreaker        T="base"       F=stub
    - C=vexriscv.lite    TC="icestorm"  P=tinyfpga_bx       T="base"       F=stub
    - C=vexriscv.lite    TC="icestorm"  P=upduino_v1        T="base"       F=stub
+   - C=vexriscv.lite    TC="icestorm"  P=icefun            T="base"       F=stub
    - C=vexriscv.lite    TC="vivado"    P=arty              T="base net"
    - C=vexriscv.lite    TC="ise"       P=opsis             T="base net"
    # PicoRV32

--- a/platforms/icefun.py
+++ b/platforms/icefun.py
@@ -1,0 +1,57 @@
+from litex.build.generic_platform import *
+from litex.build.lattice import LatticePlatform
+from litex.build.lattice.programmer import IceStormProgrammer
+
+
+_io = [
+    ("user_led", 0, Pins("B5"), IOStandard("LVCMOS33")),
+    ("user_led", 1, Pins("B4"), IOStandard("LVCMOS33")),
+    ("user_led", 2, Pins("A2"), IOStandard("LVCMOS33")),
+    ("user_led", 3, Pins("A1"), IOStandard("LVCMOS33")),
+    ("user_led", 4, Pins("C5"), IOStandard("LVCMOS33")),
+    ("user_led", 5, Pins("C4"), IOStandard("LVCMOS33")),
+    ("user_led", 6, Pins("B3"), IOStandard("LVCMOS33")),
+    ("user_led", 7, Pins("C3"), IOStandard("LVCMOS33")),
+
+    ("serial", 0,
+        Subsignal("rx", Pins("B10")),
+        Subsignal("tx", Pins("B12"), Misc("PULLUP")),
+        Subsignal("rts", Pins("B13"), Misc("PULLUP")),
+        Subsignal("cts", Pins("A15"), Misc("PULLUP")),
+        Subsignal("dtr", Pins("A16"), Misc("PULLUP")),
+        Subsignal("dsr", Pins("B14"), Misc("PULLUP")),
+        Subsignal("dcd", Pins("B15"), Misc("PULLUP")),
+        IOStandard("LVCMOS33"),
+    ),
+
+    ("spiflash", 0,
+        Subsignal("cs_n", Pins("R12"), IOStandard("LVCMOS33")),
+        Subsignal("clk", Pins("R11"), IOStandard("LVCMOS33")),
+        Subsignal("mosi", Pins("P12"), IOStandard("LVCMOS33")),
+        Subsignal("miso", Pins("P11"), IOStandard("LVCMOS33")),
+    ),
+
+    ("clk12", 0, Pins("J3"), IOStandard("LVCMOS33"))
+]
+
+
+class Platform(LatticePlatform):
+    default_clk_name = "clk12"
+    default_clk_period = 83.333
+
+    gateware_size = 0x28000
+
+    # FIXME: Create a "spi flash module" object in the same way we have SDRAM
+    spiflash_model = "n25q32"
+    spiflash_read_dummy_bits = 8
+    spiflash_clock_div = 2
+    spiflash_total_size = int((32/8)*1024*1024) # 32Mbit
+    spiflash_page_size = 256
+    spiflash_sector_size = 0x10000
+
+    def __init__(self):
+        LatticePlatform.__init__(self, "ice40-hx8k-ct256", _io,
+                                 toolchain="icestorm")
+
+    def create_programmer(self):
+        return IceStormProgrammer()

--- a/platforms/icefun.py
+++ b/platforms/icefun.py
@@ -16,6 +16,10 @@ _io = [
     # row drivers
     # top to bottom
     # C5 A6 D10 A12
+    ("user_led", 8, Pins("C5"), IOStandard("LVCMOS33")),
+    ("user_led", 9, Pins("A6"), IOStandard("LVCMOS33")),
+    ("user_led", 10, Pins("D10"), IOStandard("LVCMOS33")),
+    ("user_led", 11, Pins("A12"), IOStandard("LVCMOS33")),
 
     ("rgb_leds", 0, # you must use the ground pin between p14 and n14
         # Subsignal("r", Pins("G6 G3 J3 K1")),

--- a/platforms/icefun.py
+++ b/platforms/icefun.py
@@ -4,34 +4,55 @@ from litex.build.lattice.programmer import IceStormProgrammer
 
 
 _io = [
-    ("user_led", 0, Pins("B5"), IOStandard("LVCMOS33")),
-    ("user_led", 1, Pins("B4"), IOStandard("LVCMOS33")),
-    ("user_led", 2, Pins("A2"), IOStandard("LVCMOS33")),
-    ("user_led", 3, Pins("A1"), IOStandard("LVCMOS33")),
-    ("user_led", 4, Pins("C5"), IOStandard("LVCMOS33")),
-    ("user_led", 5, Pins("C4"), IOStandard("LVCMOS33")),
-    ("user_led", 6, Pins("B3"), IOStandard("LVCMOS33")),
-    ("user_led", 7, Pins("C3"), IOStandard("LVCMOS33")),
+    ("user_led", 0, Pins("C10"), IOStandard("LVCMOS33")),
+    ("user_led", 1, Pins("A10"), IOStandard("LVCMOS33")),
+    ("user_led", 2, Pins("D7"), IOStandard("LVCMOS33")),
+    ("user_led", 3, Pins("D6"), IOStandard("LVCMOS33")),
+    ("user_led", 4, Pins("A7"), IOStandard("LVCMOS33")),
+    ("user_led", 5, Pins("C7"), IOStandard("LVCMOS33")),
+    ("user_led", 6, Pins("A4"), IOStandard("LVCMOS33")),
+    ("user_led", 7, Pins("C4"), IOStandard("LVCMOS33")),
+
+    # row drivers
+    # top to bottom
+    # C5 A6 D10 A12
+
+    ("rgb_leds", 0, # you must use the ground pin between p14 and n14
+        # Subsignal("r", Pins("G6 G3 J3 K1")),
+        # Subsignal("g", Pins("F6 J4 J2 H6")),
+        # Subsignal("b", Pins("E1 G4 H4 K2")),
+        IOStandard("LVCMOS33")
+    ),
+
+    ("user_btn", 0, Pins("A5"), IOStandard("LVCMOS33")),
+    ("user_btn", 1, Pins("A11"), IOStandard("LVCMOS33")),
+    ("user_btn", 2, Pins("C6"), IOStandard("LVCMOS33")),
+    ("user_btn", 3, Pins("C11"), IOStandard("LVCMOS33")),
+
+    # Piezo - Two pins drive the piezo
+    # M12 M6
 
     ("serial", 0,
-        Subsignal("rx", Pins("B10")),
-        Subsignal("tx", Pins("B12"), Misc("PULLUP")),
-        Subsignal("rts", Pins("B13"), Misc("PULLUP")),
-        Subsignal("cts", Pins("A15"), Misc("PULLUP")),
-        Subsignal("dtr", Pins("A16"), Misc("PULLUP")),
-        Subsignal("dsr", Pins("B14"), Misc("PULLUP")),
-        Subsignal("dcd", Pins("B15"), Misc("PULLUP")),
+        Subsignal("rx", Pins("P2")),
+        Subsignal("tx", Pins("P3"), Misc("PULLUP")),
         IOStandard("LVCMOS33"),
     ),
 
+    ("serial", 1,
+        Subsignal("rx", Pins("P4")),
+        Subsignal("tx", Pins("P5"), Misc("PULLUP")),
+        IOStandard("LVCMOS33"),
+    ),
+
+
     ("spiflash", 0,
-        Subsignal("cs_n", Pins("R12"), IOStandard("LVCMOS33")),
-        Subsignal("clk", Pins("R11"), IOStandard("LVCMOS33")),
-        Subsignal("mosi", Pins("P12"), IOStandard("LVCMOS33")),
+        Subsignal("cs_n", Pins("P13"), IOStandard("LVCMOS33")),
+        Subsignal("clk", Pins("P12"), IOStandard("LVCMOS33")),
+        Subsignal("mosi", Pins("M11"), IOStandard("LVCMOS33")),
         Subsignal("miso", Pins("P11"), IOStandard("LVCMOS33")),
     ),
 
-    ("clk12", 0, Pins("J3"), IOStandard("LVCMOS33"))
+    ("clk12", 0, Pins("P7"), IOStandard("LVCMOS33"))
 ]
 
 
@@ -42,16 +63,18 @@ class Platform(LatticePlatform):
     gateware_size = 0x28000
 
     # FIXME: Create a "spi flash module" object in the same way we have SDRAM
-    spiflash_model = "n25q32"
+    spiflash_model = "at25sf081"
     spiflash_read_dummy_bits = 8
     spiflash_clock_div = 2
-    spiflash_total_size = int((32/8)*1024*1024) # 32Mbit
+    megabits = 8
+    spiflash_total_size = int((megabits/8)*1024*1024)
     spiflash_page_size = 256
     spiflash_sector_size = 0x10000
 
     def __init__(self):
-        LatticePlatform.__init__(self, "ice40-hx8k-ct256", _io,
+        LatticePlatform.__init__(self, "ice40-hx8k-cb132", _io,
                                  toolchain="icestorm")
 
     def create_programmer(self):
-        return IceStormProgrammer()
+        raise NotImplementedError()
+        # return IceStormProgrammer()

--- a/platforms/icefun.py
+++ b/platforms/icefun.py
@@ -64,6 +64,7 @@ class Platform(LatticePlatform):
     default_clk_name = "clk12"
     default_clk_period = 83.333
 
+    # gateware_size = 3*64*1024 # from icefundocs first 3 64k sectors reserved for FPGA
     gateware_size = 0x28000
 
     # FIXME: Create a "spi flash module" object in the same way we have SDRAM

--- a/platforms/icefun.py
+++ b/platforms/icefun.py
@@ -73,7 +73,7 @@ class Platform(LatticePlatform):
     megabits = 8
     spiflash_total_size = int((megabits/8)*1024*1024)
     spiflash_page_size = 256
-    spiflash_sector_size = 0x10000
+    spiflash_sector_size = 64*1024
 
     def __init__(self):
         LatticePlatform.__init__(self, "ice40-hx8k-cb132", _io,

--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -415,6 +415,14 @@ if [ "$PLATFORM" = "icebreaker" -o "$PLATFORM" = "ice40_hx8k_b_evn" -o "$PLATFOR
 	check_exists iceprog
 fi
 
+# icefun
+if [ "$PLATFORM" = "icefun" ]; then
+	echo
+	echo "Installing icefunprog (tool for icefun pic Programming)"
+	conda install icefunprog
+	check_exists iceFUNprog
+fi
+
 # fxload
 if [ "$PLATFORM" = "opsis" -o "$PLATFORM" = "atlys" ]; then
 	echo

--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+
+
+
+
+
 if [ "`whoami`" = "root" ]
 then
     echo "Running the script as root is not permitted"
@@ -18,6 +23,11 @@ if [ $SOURCED = 1 ]; then
 	echo "$SETUP_SRC"
 	return
 fi
+
+
+
+
+
 
 if [ ! -z "$SETTINGS_FILE" -o ! -z "$XILINX" ]; then
 	echo "You appear to have sourced the Xilinx ISE settings, these are incompatible with setting up."
@@ -39,6 +49,27 @@ if echo "${SETUP_DIR}" | grep -q ':'; then
 	exit 1
 fi
 
+# Check ixo-usb-jtag *isn't* installed
+if [ -e /lib/udev/rules.d/85-ixo-usb-jtag.rules ]; then
+	echo "Please uninstall ixo-usb-jtag package from the timvideos PPA, the"
+	echo "required firmware is included in the HDMI2USB modeswitch tool."
+	echo
+	echo "On Debian/Ubuntu run:"
+	echo "  sudo apt-get remove ixo-usb-jtag"
+	echo
+	exit 1
+fi
+
+#if [ -f /etc/udev/rules.d/99-hdmi2usb-permissions.rules -o -f /lib/udev/rules.d/99-hdmi2usb-permissions.rules -o -f /lib/udev/rules.d/60-hdmi2usb-udev.rules -o ! -z "$HDMI2USB_UDEV_IGNORE" ]; then
+#	true
+#else
+#	echo "Please install the HDMI2USB udev rules."
+#	echo "These are installed by scripts/download-env-root.sh"
+#	echo
+#	exit 1
+#fi
+
+
 set -e
 
 . $SETUP_DIR/settings.sh
@@ -51,6 +82,7 @@ echo "     3rd party directory is: $THIRD_DIR"
 # Check the build dir
 if [ ! -d $BUILD_DIR ]; then
 	mkdir -p $BUILD_DIR
+
 fi
 
 # Figure out the cpu architecture
@@ -374,6 +406,8 @@ if [ "$PLATFORM" = "tinyfpga_bx" ]; then
 	pip install "git+https://github.com/tinyfpga/TinyFPGA-Bootloader#egg=tinyprog&subdirectory=programmer&subdirectory=programmer"
 	check_exists tinyprog
 fi
+
+# iceprog compatible platforms
 if [ "$PLATFORM" = "icebreaker" -o "$PLATFORM" = "ice40_hx8k_b_evn" -o "$PLATFORM" = "ice40_up5k_b_evn" ]; then
 	echo
 	echo "Installing iceprog (tool for FTDI)"

--- a/scripts/enter-env.sh
+++ b/scripts/enter-env.sh
@@ -69,6 +69,9 @@ else
 	return 1
 fi
 
+
+
+
 . $SETUP_DIR/settings.sh
 
 echo "             This script is: $SETUP_SRC"
@@ -175,6 +178,7 @@ function check_import_version {
 	fi
 }
 
+
 echo ""
 echo "Checking environment"
 echo "---------------------------------"
@@ -188,6 +192,7 @@ eval $(cd $TOP_DIR; export HDMI2USB_ENV=1; make env || exit 1) || return 1
 	make info || exit 1
 	echo
 ) || return 1
+
 
 
 # Check the Python version
@@ -207,6 +212,8 @@ echo ""
 echo "Platform Toolchain: $PLATFORM_TOOLCHAIN"
 case $PLATFORM_TOOLCHAIN in
 	Xilinx)
+
+
 		if [ -z "$LIKELY_XILINX_LICENSE_DIR" ]; then
 			LIKELY_XILINX_LICENSE_DIR="$HOME/.Xilinx"
 		fi
@@ -320,6 +327,14 @@ if [ "$PLATFORM" = "tinyfpga_bx" ]; then
 
 
 	check_exists tinyprog || return 1
+fi
+
+# iceprog compatible platforms
+if [ "$PLATFORM" = "icebreaker" -o "$PLATFORM" = "ice40_hx8k_b_evn" -o "$PLATFORM" = "ice40_up5k_b_evn" ]; then
+
+
+
+	check_exists iceprog || return 1
 fi
 
 # fxload
@@ -490,10 +505,23 @@ fi
 
 # git commands
 echo ""
+echo "Updating git config"
+echo "-----------------------"
+(
+	cd $TOP_DIR
+
+
+
+
+
+
+)
+echo ""
 echo "Checking git submodules"
 echo "-----------------------"
 (
 	cd $TOP_DIR
+
 
 
 
@@ -513,6 +541,8 @@ for LITE in $LITE_REPOS; do
 done
 
 echo "-----------------------"
+echo ""
+echo "Completed loading environment."
 echo ""
 
 alias python=python3

--- a/scripts/enter-env.sh
+++ b/scripts/enter-env.sh
@@ -337,6 +337,14 @@ if [ "$PLATFORM" = "icebreaker" -o "$PLATFORM" = "ice40_hx8k_b_evn" -o "$PLATFOR
 	check_exists iceprog || return 1
 fi
 
+# icefun
+if [ "$PLATFORM" = "icefun" ]; then
+
+
+
+	check_exists iceFUNprog || return 1
+fi
+
 # fxload
 if [ "$PLATFORM" = "opsis" -o "$PLATFORM" = "atlys" ]; then
 

--- a/targets/icefun/Makefile.mk
+++ b/targets/icefun/Makefile.mk
@@ -1,0 +1,66 @@
+# ice40_hx8k_b_evn targets
+
+ifneq ($(PLATFORM),ice40_hx8k_b_evn)
+	$(error "Platform should be ice40_hx8k_b_evn when using this file!?")
+endif
+
+# Settings
+DEFAULT_TARGET = base
+TARGET ?= $(DEFAULT_TARGET)
+BAUD ?= 115200
+
+# Image
+image-flash-$(PLATFORM):
+	iceprog $(IMAGE_FILE)
+
+# Gateware
+gateware-load-$(PLATFORM):
+	@echo "ICE40HX8K-B-EVN doesn't support loading, use the flash target instead."
+	@echo "make gateware-flash"
+	@false
+
+# As with Mimasv2, if the user asks to flash the gateware only, the BIOS must
+# be sent as well (because the BIOS is too big to fit into the bitstream).
+GATEWARE_BIOS_FILE = $(TARGET_BUILD_DIR)/image-gateware+bios+none.bin
+
+gateware-flash-$(PLATFORM): $(GATEWARE_BIOS_FILE)
+	iceprog $(GATEWARE_BIOS_FILE)
+
+# To avoid duplicating the mkimage.py call here, if the user has not
+# already built a image-gateware+bios+none.bin, we call make recursively
+# to build one here, with the FIRMWARE=none override.
+#
+ifneq ($(GATEWARE_BIOS_FILE),$(IMAGE_FILE))
+$(GATEWARE_BIOS_FILE): $(GATEWARE_FILEBASE).bin $(BIOS_FILE) mkimage.py
+	FIRMWARE=none make image
+endif
+
+# Firmware
+firmware-load-$(PLATFORM):
+	@echo "Unsupported."
+	@false
+
+firmware-flash-$(PLATFORM):
+	@echo "ICE40HX8K-B-EVN doesn't support just flashing firmware, use image target instead."
+	@echo "make image-flash"
+	@false
+
+firmware-connect-$(PLATFORM):
+	flterm --port=$(COMM_PORT) --speed=$(BAUD)
+
+firmware-clear-$(PLATFORM):
+	@echo "FIXME: Unsupported?."
+	@false
+
+# Bios
+bios-flash-$(PLATFORM):
+	@echo "Unsupported."
+	@false
+
+# Extra commands
+help-$(PLATFORM):
+	@true
+
+reset-$(PLATFORM):
+	@echo "Unsupported."
+	@false

--- a/targets/icefun/Makefile.mk
+++ b/targets/icefun/Makefile.mk
@@ -1,7 +1,7 @@
-# ice40_hx8k_b_evn targets
+# icefun targets
 
-ifneq ($(PLATFORM),ice40_hx8k_b_evn)
-	$(error "Platform should be ice40_hx8k_b_evn when using this file!?")
+ifneq ($(PLATFORM),icefun)
+	$(error "Platform should be icefun when using this file!?")
 endif
 
 # Settings
@@ -11,11 +11,11 @@ BAUD ?= 115200
 
 # Image
 image-flash-$(PLATFORM):
-	iceprog $(IMAGE_FILE)
+	iceFUNprog $(IMAGE_FILE)
 
 # Gateware
 gateware-load-$(PLATFORM):
-	@echo "ICE40HX8K-B-EVN doesn't support loading, use the flash target instead."
+	@echo "iceFun doesn't support loading, use the flash target instead."
 	@echo "make gateware-flash"
 	@false
 
@@ -24,7 +24,7 @@ gateware-load-$(PLATFORM):
 GATEWARE_BIOS_FILE = $(TARGET_BUILD_DIR)/image-gateware+bios+none.bin
 
 gateware-flash-$(PLATFORM): $(GATEWARE_BIOS_FILE)
-	iceprog $(GATEWARE_BIOS_FILE)
+	iceFUNprog $(GATEWARE_BIOS_FILE)
 
 # To avoid duplicating the mkimage.py call here, if the user has not
 # already built a image-gateware+bios+none.bin, we call make recursively
@@ -41,7 +41,7 @@ firmware-load-$(PLATFORM):
 	@false
 
 firmware-flash-$(PLATFORM):
-	@echo "ICE40HX8K-B-EVN doesn't support just flashing firmware, use image target instead."
+	@echo "iceFun doesn't support just flashing firmware, use image target instead."
 	@echo "make image-flash"
 	@false
 

--- a/targets/icefun/base.py
+++ b/targets/icefun/base.py
@@ -1,0 +1,104 @@
+import sys
+import struct
+import os.path
+import argparse
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+from litex.build.generic_platform import Pins, Subsignal, IOStandard
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+
+from gateware import cas
+from gateware import spi_flash
+
+from targets.utils import csr_map_update
+
+
+class _CRG(Module):
+    def __init__(self, platform):
+        clk12 = platform.request("clk12")
+
+        self.clock_domains.cd_sys = ClockDomain()
+        self.reset = Signal()
+
+        # FIXME: Use PLL, increase system clock to 32 MHz, pending nextpnr
+        # fixes.
+        self.comb += self.cd_sys.clk.eq(clk12)
+
+        # POR reset logic- POR generated from sys clk, POR logic feeds sys clk
+        # reset.
+        self.clock_domains.cd_por = ClockDomain()
+        reset_delay = Signal(12, reset=4095)
+        self.comb += [
+            self.cd_por.clk.eq(self.cd_sys.clk),
+            self.cd_sys.rst.eq(reset_delay != 0)
+        ]
+        self.sync.por += \
+            If(reset_delay != 0,
+                reset_delay.eq(reset_delay - 1)
+            )
+        self.specials += AsyncResetSynchronizer(self.cd_por, self.reset)
+
+
+class BaseSoC(SoCCore):
+    csr_peripherals = (
+        "spiflash",
+        "cas",
+    )
+    csr_map_update(SoCCore.csr_map, csr_peripherals)
+
+    mem_map = {
+        "spiflash": 0x20000000,  # (default shadow @0xa0000000)
+    }
+    mem_map.update(SoCCore.mem_map)
+
+    def __init__(self, platform, **kwargs):
+        if 'integrated_rom_size' not in kwargs:
+            kwargs['integrated_rom_size']=0
+        if 'integrated_sram_size' not in kwargs:
+            kwargs['integrated_sram_size']=0x2800
+
+        # FIXME: Force either lite or minimal variants of CPUs; full is too big.
+
+        clk_freq = int(12e6)
+
+        kwargs['cpu_reset_address']=self.mem_map["spiflash"]+platform.gateware_size
+        SoCCore.__init__(self, platform, clk_freq, **kwargs)
+
+        self.submodules.crg = _CRG(platform)
+        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/clk_freq)
+
+        # Control and Status
+        self.submodules.cas = cas.ControlAndStatus(platform, clk_freq)
+
+        # SPI flash peripheral
+        self.submodules.spiflash = spi_flash.SpiFlashSingle(
+            platform.request("spiflash"),
+            dummy=platform.spiflash_read_dummy_bits,
+            div=platform.spiflash_clock_div)
+        self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
+        self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
+        self.register_mem("spiflash", self.mem_map["spiflash"],
+            self.spiflash.bus, size=platform.spiflash_total_size)
+
+        bios_size = 0x8000
+        self.add_constant("ROM_DISABLE", 1)
+        self.add_memory_region("rom", kwargs['cpu_reset_address'], bios_size)
+        self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+
+        # We don't have a DRAM, so use the remaining SPI flash for user
+        # program.
+        self.add_memory_region("user_flash",
+            self.flash_boot_address,
+            # Leave a grace area- possible one-by-off bug in add_memory_region?
+            # Possible fix: addr < origin + length - 1
+            platform.spiflash_total_size - (self.flash_boot_address - self.mem_map["spiflash"]) - 0x100)
+
+        # Disable final deep-sleep power down so firmware words are loaded
+        # onto softcore's address bus.
+        platform.toolchain.build_template[3] = "icepack -s {build_name}.txt {build_name}.bin"
+        platform.toolchain.nextpnr_build_template[2] = "icepack -s {build_name}.txt {build_name}.bin"
+
+SoC = BaseSoC


### PR DESCRIPTION
Tracking the initial porting of IceFun board, See #181 

Platform and targets based on ice40_hx8k_b_evnboard 

- [x] Add iceFun to travis
- [x] Add board to spreadsheet of supported boards
- [x] Conda package for iceFUNprog
- [x] Add to How to Ice40 guide https://github.com/timvideos/litex-buildenv/wiki/HowTo-FuPy-on-iCE40-Boards


I've moved the rest of the todos to issue #181, I'll follow up later with another PR for the rest, but I'd like to get this mainlined.


