### PR TITLE
Small README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,13 @@ and troubleshooting capabilities.
 To bootstrap or update your environment one generally does:
 
 ```
-# Download the debian packages needed to support litex environment.  Usually
-# we only do this once.
-./scripts/download-env-root.sh
+# Install system wide dependencies;
+#  * wget
+#  * bash
+#  * make
+#  * udev rules from https://github.com/litex-hub/litex-buildenv-udev
+#
+# On Debian you can use the ./scripts/debian-setup.sh script.
 
 # Download/update the litex specific packages (python, verilator, submodules etc)
 ./scripts/download-env.sh

--- a/scripts/debian-setup.sh
+++ b/scripts/debian-setup.sh
@@ -30,9 +30,6 @@ apt-get install -y gtkwave
 # FIXME: What needs python-yaml!?
 apt-get install -y python-yaml
 
-# fxload is needed for controlling the FX2 found on the Atlys and Opsis boards
-apt-get install -y fxload
-
 # aftpd is needed for tftp booting firmware
 apt-get install -y atftpd
 

--- a/scripts/debian-setup.sh
+++ b/scripts/debian-setup.sh
@@ -27,9 +27,6 @@ apt-get install -y build-essential
 # gtkwave is needed for viewing the output of traces
 apt-get install -y gtkwave
 
-# readline, libusb, libftdi are all needed by openocd which is installed via conda
-apt-get install -y libreadline-dev libusb-1.0-0-dev libftdi-dev
-
 # FIXME: What needs python-yaml!?
 apt-get install -y python-yaml
 


### PR DESCRIPTION
 * Remove dependencies no longer needed from `scripts/debian-setup.sh`.
 * Update the README documentation to remove references to `scripts/download-env-root.sh`.