### PR TITLE
Complete the renaming of download-env-root.sh to debian-setup.sh.

### DIFF
--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -64,7 +64,7 @@ fi
 #	true
 #else
 #	echo "Please install the HDMI2USB udev rules."
-#	echo "These are installed by scripts/download-env-root.sh"
+#	echo "These are installed by scripts/debian-setup.sh"
 #	echo
 #	exit 1
 #fi

--- a/scripts/enter-env.sh
+++ b/scripts/enter-env.sh
@@ -63,7 +63,7 @@ fi
 if [ -f /etc/udev/rules.d/99-hdmi2usb-permissions.rules -o -f /lib/udev/rules.d/99-hdmi2usb-permissions.rules -o -f /lib/udev/rules.d/60-hdmi2usb-udev.rules -o ! -z "$HDMI2USB_UDEV_IGNORE" ]; then
 	true
 else
-	echo "Please install the HDMI2USB udev rules."
+	echo "Please install the HDMI2USB udev rules, or `export HDMI2USB_UDEV_IGNORE=somevalue` to ignore this."
 	echo "On Debian/Ubuntu, these can be installed by running scripts/debian-setup.sh"
 	echo
 	return 1

--- a/scripts/enter-env.sh
+++ b/scripts/enter-env.sh
@@ -64,7 +64,7 @@ if [ -f /etc/udev/rules.d/99-hdmi2usb-permissions.rules -o -f /lib/udev/rules.d/
 	true
 else
 	echo "Please install the HDMI2USB udev rules."
-	echo "These are installed by scripts/download-env-root.sh"
+	echo "These are installed by scripts/debian-setup.sh"
 	echo
 	return 1
 fi

--- a/scripts/enter-env.sh
+++ b/scripts/enter-env.sh
@@ -64,7 +64,7 @@ if [ -f /etc/udev/rules.d/99-hdmi2usb-permissions.rules -o -f /lib/udev/rules.d/
 	true
 else
 	echo "Please install the HDMI2USB udev rules."
-	echo "These are installed by scripts/debian-setup.sh"
+	echo "On Debian/Ubuntu, these can be installed by running scripts/debian-setup.sh"
 	echo
 	return 1
 fi


### PR DESCRIPTION
Commit 63e30284a257de04848869cb1cbd1ca5f6c55c9d
Date:   2019-05-03 19:39:22 -0700

>      * Rename `download-env-root.sh` to `debian-setup.sh` (should stop
>        people thinking we are Debian only).

File was renamed but old name appears in scripts (one real, one in a commented-out section).

This PR fixes.
