### PR TITLE
scripts: Support both iCE40 and ECP5 toolchains.

### DIFF
--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -337,6 +337,9 @@ case $PLATFORM_TOOLCHAIN in
 		fi
 		;;
 	Lattice)
+		LATTICE_FULL_PART="$(grep 'LatticePlatform.__init__' platforms/*.py | sed -e's/.*(self, "//' -e's/".*//')"
+
+
 		export HAVE_FPGA_TOOLCHAIN=1
 		# yosys
 		echo
@@ -344,11 +347,25 @@ case $PLATFORM_TOOLCHAIN in
 		conda install -y $CONDA_FLAGS yosys
 		check_exists yosys
 
+
 		# nextpnr
 		echo
-		echo "Installing nextpnr (FOSS Place and Route tool)"
-		conda install -y $CONDA_FLAGS nextpnr
-		check_exists nextpnr-ice40
+		echo "Installing nextpnr (FOSS Place and Route tool) for $LATTICE_FULL_PART"
+		case $LATTICE_FULL_PART in
+			ice40*)
+				conda install -y $CONDA_FLAGS nextpnr-ice40
+				check_exists nextpnr-ice40
+				;;
+			ecp5*)
+				conda install -y $CONDA_FLAGS nextpnr-ecp5
+				check_exists nextpnr-ecp5
+				;;
+			*)
+				echo "Unknown Lattice part $LATTICE_FULL_PART"
+				exit 1
+				;;
+		esac
+
 		;;
 	*)
 		;;

--- a/scripts/enter-env.sh
+++ b/scripts/enter-env.sh
@@ -284,6 +284,9 @@ case $PLATFORM_TOOLCHAIN in
 		fi
 		;;
 	Lattice)
+		LATTICE_FULL_PART="$(grep 'LatticePlatform.__init__' platforms/*.py | sed -e's/.*(self, "//' -e's/".*//')"
+
+
 		export HAVE_FPGA_TOOLCHAIN=1
 		# yosys
 
@@ -291,11 +294,25 @@ case $PLATFORM_TOOLCHAIN in
 
 		check_exists yosys || return 1
 
+
 		# nextpnr
 
 
+		case $LATTICE_FULL_PART in
+			ice40*)
 
-		check_exists nextpnr-ice40 || return 1
+				check_exists nextpnr-ice40 || return 1
+				;;
+			ecp5*)
+
+				check_exists nextpnr-ecp5 || return 1
+				;;
+			*)
+				echo "Unknown Lattice part $LATTICE_FULL_PART"
+				return 1
+				;;
+		esac
+
 		;;
 	*)
 		;;


### PR DESCRIPTION
 * Fixes conda package name (nextpnr -> nextpnr-ice40).
 * Detect if iCE40 or ECP5 toolchain is needed.