### PR TITLE
Allow to pass additional arguments to Renode

### DIFF
--- a/scripts/build-renode.sh
+++ b/scripts/build-renode.sh
@@ -98,5 +98,11 @@ python $TOP_DIR/third_party/litex-renode/generate-renode-scripts.py $LITEX_CONFI
 	--firmware-binary "$TARGET_BUILD_DIR/software/$FIRMWARE/firmware.bin" \
 	--configure-network ${TAP_INTERFACE:-""}
 
-$RENODE_BIN "$RENODE_RESC"
+# 1. include the generated script
+# 2. set additional parameters
+# 3. start the simulation
+$RENODE_BIN \
+	-e "i @$RENODE_RESC" \
+	"$@" \
+	-e "s"
 


### PR DESCRIPTION
This PR changes the way Renode is started by the `./scripts/build-renode.sh` script.

Instead of just passing a generated `resc` script to Renode, a series of `-e` switches is used. It allows user to pass own additional arguments before starting the simulation.

*Note:* currently the generated script contains a `start` command at the end so the last `-e s` is not necessary, but once this PR is merged I will remove the final `start` from the generator. Proceeding in this order is to ensure that this script works during the transition period.