### PR TITLE
Use Renode from Conda

### DIFF
--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -44,7 +44,7 @@ if [ "$FIRMWARE" != "linux" ]; then
 fi
 
 # Install a baremetal toolchain with the newlib standard library
-if ! ${CPU_ARCH}-elf-newlib --version > /dev/null 2>&1; then
+if ! ${CPU_ARCH}-elf-newlib-gcc --version > /dev/null 2>&1; then
 	conda install gcc-${CPU_ARCH}-elf-newlib
 fi
 # Install a Linux userspace toolchain with the musl standard library

--- a/scripts/build-renode.sh
+++ b/scripts/build-renode.sh
@@ -26,24 +26,7 @@ fi
 
 if ! $RENODE_FOUND; then
 	# Download prebuilt renode Release if none is currently installed
-
-	RENODE_PACKAGE=renode-latest.linux-portable.tar.gz
-	RENODE_URL=https://antmicro.com/projects/renode/builds/$RENODE_PACKAGE
-	RENODE_LOCATION="$BUILD_DIR/renode"
-	mkdir -p $RENODE_LOCATION
-
-	RENODE_BIN=`find $RENODE_LOCATION -executable -type f -name renode`
-	if [ ! -x "$RENODE_BIN" ]; then
-		(
-			cd $RENODE_LOCATION
-			wget $RENODE_URL
-			tar -xf $RENODE_PACKAGE
-		)
-
-		RENODE_BIN=`find $RENODE_LOCATION -executable -type f -name renode`
-		chmod u+x $RENODE_BIN
-		echo "Renode downloaded and installed locally: $RENODE_BIN"
-	fi
+	conda install -c antmicro -c conda-forge renode
 fi
 
 case $CPU in

--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -74,6 +74,10 @@ set -e
 
 . $SETUP_DIR/settings.sh
 
+# If we activate an environment, CONDA_PREFIX is set. Otherwise use CONDA_DIR.
+export CONDA_PREFIX="${CONDA_PREFIX:-$CONDA_DIR}"
+export CONDA_DIR=$CONDA_PREFIX
+
 echo "             This script is: $SETUP_SRC"
 echo "         Firmware directory: $TOP_DIR"
 echo "         Build directory is: $BUILD_DIR"

--- a/scripts/enter-env.sh
+++ b/scripts/enter-env.sh
@@ -74,6 +74,10 @@ fi
 
 . $SETUP_DIR/settings.sh
 
+# If we activate an environment, CONDA_PREFIX is set. Otherwise use CONDA_DIR.
+export CONDA_PREFIX="${CONDA_PREFIX:-$CONDA_DIR}"
+export CONDA_DIR=$CONDA_PREFIX
+
 echo "             This script is: $SETUP_SRC"
 echo "         Firmware directory: $TOP_DIR"
 echo "         Build directory is: $BUILD_DIR"


### PR DESCRIPTION
This is an introductory PR for conda-pack support. It does 3 things:

- fixes verification of gcc installation
- moves Renode to use conda instead of regular packages
- adds CONDA_PREFIX variable (required for Renode)
