### PR TITLE
platforms: add pano logic g2 platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,7 @@ env:
    - C=vexriscv.lite    TC="icestorm"  P=icefun            T="base"       F=stub
    - C=vexriscv.lite    TC="vivado"    P=arty              T="base net"
    - C=vexriscv.lite    TC="ise"       P=opsis             T="base net"
+   - C=vexriscv.lite    TC="ise"       P=pano_logic_g2     T="base"
    # PicoRV32
    - C=picorv32         TC="vivado"    P=arty              T="base net"
    - C=picorv32         TC="vivado"    P=mimas_a7          T="base net"
@@ -141,6 +142,7 @@ jobs:
   allow_failures:
    - env: C=lm32             TC="vivado"    P=nexys_video       T="video"
    - env: C=mor1kx.linux     TC="vivado"    P=nexys_video       T="net"        F=linux
+   - env: C=vexriscv.lite    TC="ise"       P=pano_logic_g2     T="base"
 
 notifications:
  email:

--- a/platforms/pano_logic_g2.py
+++ b/platforms/pano_logic_g2.py
@@ -1,0 +1,185 @@
+# Support for the Pano Logic Zero Client G2
+# More information about the board and the reverse engineering results
+# can be found here https://github.com/tomverbeure/panologic-g2
+
+from litex.build.generic_platform import *
+from litex.build.xilinx import XilinxPlatform, iMPACT
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_io = [
+    # NET "led_red" LOC = E12 | IOSTANDARD = LVCMOS33;
+    # NET "led_blue" LOC = H13 | IOSTANDARD = LVCMOS33;
+    # NET "led_green" LOC = F13 | IOSTANDARD = LVCMOS33;
+    ("user_led", 0, Pins("E12"), IOStandard("LVCMOS33")),
+    ("user_led", 1, Pins("H13"),  IOStandard("LVCMOS33")),
+    ("user_led", 2, Pins("F13"),  IOStandard("LVCMOS33")),
+
+    # NET "pano_button" LOC = H12 | IOSTANDARD = LVCMOS33;
+    ("user_sw", 0, Pins("H12"), IOStandard("LVCMOS33")),
+
+    # NET "osc_clk" LOC = Y13 | IOSTANDARD = LVCMOS33;
+    ("clk125", 0, Pins("Y13"), IOStandard("LVCMOS33")),
+
+    # NET "DDC1_SCK" LOC = C14 | IOSTANDARD = LVCMOS33;
+    # NET "DDC1_SDA" LOC = C17 | IOSTANDARD = LVCMOS33;
+    ("serial", 0,
+        Subsignal("tx", Pins("C14"), IOStandard("LVCMOS33")),
+        Subsignal("rx", Pins("C17"), IOStandard("LVCMOS33"))
+    ),
+
+    # NET "GMII_RST_N" LOC = R11 | IOSTANDARD = LVCMOS33;
+    ("gmii_rst_n", 0, Pins("R11"), IOStandard("LVCMOS33")),
+
+    # NET "SYSRST_N" LOC = AB14 | IOSTANDARD = LVCMOS33;
+    ("cpu_reset", 0, Pins("AB14"), IOStandard("LVCMOS33")),
+
+    # NET "DDR2A_CK_P" LOC = H20 | IOSTANDARD = LVCMOS18;
+    # NET "DDR2A_CK_N" LOC = J19 | IOSTANDARD = LVCMOS18;
+    ("ddram_clock_a", 0,
+        Subsignal("p", Pins("H20")),
+        Subsignal("n", Pins("J19")),
+        IOStandard("DIFF_SSTL18_II"), Misc("IN_TERM=NONE")
+    ),
+
+    # NET "DDR2B_CK_P" LOC = H4 | IOSTANDARD = LVCMOS18;
+    # NET "DDR2B_CK_N" LOC = H3 | IOSTANDARD = LVCMOS18;
+    ("ddram_clock_b", 0,
+        Subsignal("p", Pins("H4")),
+        Subsignal("n", Pins("H3")),
+        IOStandard("DIFF_SSTL18_II"), Misc("IN_TERM=NONE")
+    ),
+
+    ("ddram_a", 0,
+        # NET "DDR2A_A[12]" LOC = D22 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_A[11]" LOC = F19 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_A[10]" LOC = G19 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_A[9]" LOC = C22 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_A[8]" LOC = C20 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_A[7]" LOC = E20 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_A[6]" LOC = K19 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_A[5]" LOC = K20 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_A[4]" LOC = F20 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_A[3]" LOC = G20 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_A[2]" LOC = E22 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_A[1]" LOC = F22 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_A[0]" LOC = F21 | IOSTANDARD = LVCMOS18;
+        Subsignal("a", Pins("F21 F22 E22 G20 F20 K20 K19 E20 C20 C22 G19 F19 D22"), IOStandard("SSTL18_II")),
+        # NET "DDR2A_BA[2]" LOC = H18 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_BA[1]" LOC = K17 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_BA[0]" LOC = J17 | IOSTANDARD = LVCMOS18;
+        Subsignal("ba", Pins("J17 K17 H18"), IOStandard("SSTL18_II")),
+        # NET "DDR2A_RAS_L" LOC = H21 | IOSTANDARD = LVCMOS18;
+        Subsignal("ras_n", Pins("H21"), IOStandard("SSTL18_II")),
+        # NET "DDR2A_CAS_L" LOC = H22 | IOSTANDARD = LVCMOS18;
+        Subsignal("cas_n", Pins("H22"), IOStandard("SSTL18_II")),
+        # NET "DDR2A_WE_L" LOC = H19 | IOSTANDARD = LVCMOS18;
+        Subsignal("we_n", Pins("H19"), IOStandard("SSTL18_II")),
+        # NET "DDR2A_UDM" LOC = M20 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_LDM" LOC = L19 | IOSTANDARD = LVCMOS18;
+        Subsignal("dm", Pins("M20 L19"), IOStandard("SSTL18_II")),
+        # NET "DDR2A_D[0]" LOC = N20 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_D[1]" LOC = N22 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_D[2]" LOC = M21 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_D[3]" LOC = M22 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_D[4]" LOC = J20 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_D[5]" LOC = J22 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_D[6]" LOC = K21 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_D[7]" LOC = K22 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_D[8]" LOC = P21 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_D[9]" LOC = P22 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_D[10]" LOC = R20 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_D[11]" LOC = R22 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_D[12]" LOC = U20 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_D[13]" LOC = U22 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_D[14]" LOC = V21 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_D[15]" LOC = V22 | IOSTANDARD = LVCMOS18;
+        Subsignal("dq", Pins("N20 N22 M21 M22 J20 J22 K21 K22 P21 P22 R20 R22 U20 U22 V21 V22"), IOStandard("SSTL18_II")),
+        # NET "DDR2A_UDQS_P" LOC = T21 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_LDQS_P" LOC = L20 | IOSTANDARD = LVCMOS18;
+        Subsignal("dqs", Pins("T21 L20"), IOStandard("DIFF_SSTL18_II")),
+        # NET "DDR2A_UDQS_N" LOC = T22 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2A_LDQS_N" LOC = L22 | IOSTANDARD = LVCMOS18;
+        Subsignal("dqs_n", Pins("T22 L22"), IOStandard("DIFF_SSTL18_II")),
+        # NET "DDR2A_CKE" LOC = D21 | IOSTANDARD = LVCMOS18;
+        Subsignal("cke", Pins("D21"), IOStandard("SSTL18_II")),
+        # NET "DDR2A_ODT" LOC = G22 | IOSTANDARD = LVCMOS18;
+        Subsignal("odt", Pins("G22"), IOStandard("SSTL18_II")),
+    ),
+
+    ("ddram_b", 0,
+        # NET "DDR2B_A[12]" LOC = D1 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_A[11]" LOC = C1 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_A[10]" LOC = G4 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_A[9]" LOC = E1 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_A[8]" LOC = E3 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_A[7]" LOC = H6 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_A[6]" LOC = J4 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_A[5]" LOC = K3 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_A[4]" LOC = F3 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_A[3]" LOC = K6 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_A[2]" LOC = H5 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_A[1]" LOC = H1 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_A[0]" LOC = H2 | IOSTANDARD = LVCMOS18;
+        Subsignal("a", Pins("H2 H1 H5 K6 F3 K3 J4 H6 E3 E1 G4 C1 D1"), IOStandard("SSTL18_II")),
+        # NET "DDR2B_BA[2]" LOC = F1 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_BA[1]" LOC = G1 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_BA[0]" LOC = G3 | IOSTANDARD = LVCMOS18;
+        Subsignal("ba", Pins("G3 G1 F1"), IOStandard("SSTL18_II")),
+        # NET "DDR2B_RAS_L" LOC = K5 | IOSTANDARD = LVCMOS18;
+        Subsignal("ras_n", Pins("K5"), IOStandard("SSTL18_II")),
+        # NET "DDR2B_CAS_L" LOC = K4 | IOSTANDARD = LVCMOS18;
+        Subsignal("cas_n", Pins("K4"), IOStandard("SSTL18_II")),
+        # NET "DDR2B_WE_L" LOC = F2 | IOSTANDARD = LVCMOS18;
+        Subsignal("we_n", Pins("F2"), IOStandard("SSTL18_II")),
+        # NET "DDR2B_UDM" LOC = M3 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_LDM" LOC = L4 | IOSTANDARD = LVCMOS18;
+        Subsignal("dm", Pins("M3 L4"), IOStandard("SSTL18_II")),
+        # NET "DDR2B_D[15]" LOC = V1 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_D[14]" LOC = V2 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_D[13]" LOC = U1 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_D[12]" LOC = U3 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_D[11]" LOC = R1 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_D[10]" LOC = R3 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_D[9]" LOC = P1 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_D[8]" LOC = P2 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_D[7]" LOC = K1 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_D[6]" LOC = K2 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_D[5]" LOC = J1 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_D[4]" LOC = J3 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_D[3]" LOC = M1 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_D[2]" LOC = M2 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_D[1]" LOC = N1 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_D[0]" LOC = N3 | IOSTANDARD = LVCMOS18;
+        Subsignal("dq", Pins("N3 N1 M2 M1 J3 J1 K2 K1 P2 P1 R3 R1 U3 U1 V2 V1"), IOStandard("SSTL18_II")),
+        # NET "DDR2B_UDQS_P" LOC = T2 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_LDQS_P" LOC = L3 | IOSTANDARD = LVCMOS18;
+        Subsignal("dqs", Pins("T2 L3"), IOStandard("DIFF_SSTL18_II")),
+        # NET "DDR2B_UDQS_N" LOC = T1 | IOSTANDARD = LVCMOS18;
+        # NET "DDR2B_LDQS_N" LOC = L1 | IOSTANDARD = LVCMOS18;
+        Subsignal("dqs_n", Pins("T1 L1"), IOStandard("DIFF_SSTL18_II")),
+        # NET "DDR2B_CKE" LOC = D2 | IOSTANDARD = LVCMOS18;
+        Subsignal("cke", Pins("D2"), IOStandard("SSTL18_II")),
+        # NET "DDR2B_ODT" LOC = J6 | IOSTANDARD = LVCMOS18;
+        Subsignal("odt", Pins("J6"), IOStandard("SSTL18_II")),
+    ),
+]
+
+# Platform -----------------------------------------------------------------------------------------
+
+class Platform(XilinxPlatform):
+    name = "pano logic g2"
+    default_clk_name = "clk125"
+    default_clk_period = 1e9/125e6
+
+    def __init__(self, programmer="impact", device="xc6slx150"):
+        XilinxPlatform.__init__(self, device+"-2-fgg484", _io)
+        self.programmer = programmer
+
+        self.add_platform_command("""CONFIG VCCAUX="2.5";""")
+
+    def create_programmer(self):
+        if self.programmer == "impact":
+            return iMPACT()
+        else:
+            raise ValueError("{} programmer is not supported".format(self.programmer))

--- a/targets/pano_logic_g2/Makefile.mk
+++ b/targets/pano_logic_g2/Makefile.mk
@@ -1,0 +1,50 @@
+# Pano Logic Zero Client G2 targets
+
+ifneq ($(PLATFORM),pano_logic_g2)
+	$(error "Platform should be pano_logic_g2 when using this file!?")
+endif
+
+# Settings
+DEFAULT_TARGET = base
+TARGET ?= $(DEFAULT_TARGET)
+
+COMM_PORT ?= /dev/ttyUSB0
+BAUD ?= 115200
+
+# Image
+image-flash-$(PLATFORM):
+	@echo "Unsupported"
+	@false
+
+# Gateware
+gateware-load-$(PLATFORM):
+	@echo "Unsupported"
+	@false
+
+gateware-flash-$(PLATFORM):
+	@echo "Unsupported"
+	@false
+
+# Firmware
+firmware-load-$(PLATFORM):
+	flterm --port=$(COMM_PORT) --kernel=$(FIRMWARE_FILEBASE).bin --speed=$(BAUD)
+
+firmware-flash-$(PLATFORM):
+	@echo "Unsupported"
+	@false
+
+firmware-connect-$(PLATFORM):
+	flterm --port=$(COMM_PORT) --speed=$(BAUD)
+
+# Bios
+bios-flash-$(PLATFORM):
+	@echo "Unsupported"
+	@false
+
+# Extra commands
+help-$(PLATFORM):
+	@true
+
+reset-$(PLATFORM):
+	@echo "Unsupported"
+	@false

--- a/targets/pano_logic_g2/base.py
+++ b/targets/pano_logic_g2/base.py
@@ -1,0 +1,191 @@
+# Support for the Pano Logic Zero Client G2
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+from litex.soc.interconnect import wishbone
+from litex.soc.integration.soc_sdram import *
+from litex.soc.integration.builder import *
+
+from litedram.modules import MT47H32M16
+from litedram.phy import s6ddrphy
+from litedram.core import ControllerSettings
+
+from gateware import info
+from gateware import cas
+
+from targets.utils import csr_map_update
+
+
+class _CRG(Module):
+    def __init__(self, platform):
+        self.clock_domains.cd_sys = ClockDomain()
+        self.clock_domains.cd_sdram_half = ClockDomain()
+        self.clock_domains.cd_sdram_full_wr = ClockDomain()
+        self.clock_domains.cd_sdram_full_rd = ClockDomain()
+
+        self.reset = Signal()
+
+        f0 = int(125e6)
+
+        clk125 = platform.request(platform.default_clk_name)
+        clk125a = Signal()
+
+        self.specials += Instance("IBUFG", i_I=clk125, o_O=clk125a)
+
+        clk125b = Signal()
+
+        self.specials += Instance(
+            "BUFIO2", p_DIVIDE=1,
+            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
+            i_I=clk125a, o_DIVCLK=clk125b)
+
+        unbuf_sdram_full = Signal()
+        unbuf_sdram_half_a = Signal()
+        unbuf_sdram_half_b = Signal()
+        unbuf_encoder = Signal()
+        unbuf_sys = Signal()
+        unbuf_unused = Signal()
+
+        # PLL signals
+        pll_lckd = Signal()
+        pll_fb = Signal()
+        self.specials.pll = Instance(
+            "PLL_ADV",
+            name="crg_pll_adv",
+            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
+            p_REF_JITTER=.01,
+            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
+            p_DIVCLK_DIVIDE=1,
+            # Input Clocks (125MHz)
+            i_CLKIN1=clk125b,
+            p_CLKIN1_PERIOD=platform.default_clk_period,
+            i_CLKIN2=0,
+            p_CLKIN2_PERIOD=0.,
+            i_CLKINSEL=1,
+            # Feedback
+            # (1000MHz) vco
+            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
+            p_CLK_FEEDBACK="CLKFBOUT",
+            p_CLKFBOUT_MULT=8, p_CLKFBOUT_PHASE=0.,
+            # (200MHz) sdram wr rd
+            o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
+            p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=5,
+            # (100MHz) unused
+            o_CLKOUT1=unbuf_encoder, p_CLKOUT1_DUTY_CYCLE=.5,
+            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=10,
+            # (100MHz) sdram_half - sdram dqs adr ctrl
+            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
+            p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=10,
+            # (100MHz) off-chip ddr
+            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
+            p_CLKOUT3_PHASE=250., p_CLKOUT3_DIVIDE=10,
+            # (100MHz) unused
+            o_CLKOUT4=unbuf_unused, p_CLKOUT4_DUTY_CYCLE=.5,
+            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=10,
+            # ( 50MHz) sysclk
+            o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
+            p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=20,
+        )
+
+        # power on reset?
+        reset = ~platform.request("cpu_reset") | self.reset
+        self.clock_domains.cd_por = ClockDomain()
+        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
+        self.sync.por += If(por != 0, por.eq(por - 1))
+        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
+
+        # System clock - 50MHz
+        self.specials += Instance("BUFG", name="sys_bufg", i_I=unbuf_sys, o_O=self.cd_sys.clk)
+        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
+
+        # SDRAM clocks
+        # ------------------------------------------------------------------------------
+        self.clk4x_wr_strb = Signal()
+        self.clk4x_rd_strb = Signal()
+
+        # sdram_full
+        self.specials += Instance("BUFPLL", name="sdram_full_bufpll",
+                                  p_DIVIDE=4,
+                                  i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys.clk,
+                                  i_LOCKED=pll_lckd,
+                                  o_IOCLK=self.cd_sdram_full_wr.clk,
+                                  o_SERDESSTROBE=self.clk4x_wr_strb)
+        self.comb += [
+            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
+            self.clk4x_rd_strb.eq(self.clk4x_wr_strb),
+        ]
+        # sdram_half
+        self.specials += Instance("BUFG", name="sdram_half_a_bufpll", i_I=unbuf_sdram_half_a, o_O=self.cd_sdram_half.clk)
+        clk_sdram_half_shifted = Signal()
+        self.specials += Instance("BUFG", name="sdram_half_b_bufpll", i_I=unbuf_sdram_half_b, o_O=clk_sdram_half_shifted)
+
+        output_clk = Signal()
+        clk = platform.request("ddram_clock_b")
+        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
+                                  p_INIT=0, p_SRTYPE="SYNC",
+                                  i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
+                                  i_C0=clk_sdram_half_shifted,
+                                  i_C1=~clk_sdram_half_shifted,
+                                  o_Q=output_clk)
+        self.specials += Instance("OBUFDS", i_I=output_clk, o_O=clk.p, o_OB=clk.n)
+
+class BaseSoC(SoCSDRAM):
+    csr_peripherals = (
+        "ddrphy",
+        "info",
+        "cas",
+    )
+    csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
+
+    mem_map = {
+        "emulator_ram": 0x50000000,  # (default shadow @0xd0000000)
+    }
+    mem_map.update(SoCSDRAM.mem_map)
+
+    def __init__(self, platform, **kwargs):
+        if 'integrated_rom_size' not in kwargs:
+            kwargs['integrated_rom_size']=0x8000
+        if 'integrated_sram_size' not in kwargs:
+            kwargs['integrated_sram_size']=0x8000
+
+        clk_freq = int(50e6)
+        SoCSDRAM.__init__(self, platform, clk_freq, **kwargs)
+
+        self.submodules.crg = _CRG(platform)
+        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/clk_freq)
+
+        self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.submodules.cas = cas.ControlAndStatus(platform, clk_freq)
+
+        gmii_rst_n = platform.request("gmii_rst_n")
+
+        self.comb += [
+            gmii_rst_n.eq(1)
+        ]
+
+        if self.cpu_type == "vexriscv" and self.cpu_variant == "linux":
+            size = 0x4000
+            self.submodules.emulator_ram = wishbone.SRAM(size)
+            self.register_mem("emulator_ram", self.mem_map["emulator_ram"], self.emulator_ram.bus, size)
+
+        # sdram
+        sdram_module = MT47H32M16(self.clk_freq, "1:2")
+        self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
+            platform.request("ddram_b"),
+            sdram_module.memtype,
+            rd_bitslip=0,
+            wr_bitslip=4,
+            dqs_ddr_alignment="C0")
+        controller_settings = ControllerSettings(with_bandwidth=True)
+        self.register_sdram(self.ddrphy,
+                            sdram_module.geom_settings,
+                            sdram_module.timing_settings,
+                            controller_settings=controller_settings)
+        self.comb += [
+            self.ddrphy.clk4x_wr_strb.eq(self.crg.clk4x_wr_strb),
+            self.ddrphy.clk4x_rd_strb.eq(self.crg.clk4x_rd_strb),
+        ]
+
+
+SoC = BaseSoC


### PR DESCRIPTION
Aim of this PR is to add initial support for [Pano Logic Zero Client G2](https://github.com/tomverbeure/panologic-g2).
Initial version supports only a basic set of features:
* UART exposed on DVI DDC pins
* Single DDR2 chip

With this configuration it is possible to run Linux built using `./scripts/build-linux.sh`, only catch is that it must be transferred over a serial connection.

Additionally I'm not sure how should I implement the `gateware-load` target and similar because the device has only a JTAG header and no built-in programmer