### PR TITLE
scripts/build-linux.sh: add option to build rootfs and devicetree from scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ third_party/qemu-litex
 third_party/micropython
 third_party/linux
 third_party/litex-devicetree
+third_party/buildroot
+third_party/linux-on-litex-vexriscv

--- a/make.py
+++ b/make.py
@@ -133,6 +133,9 @@ def main():
         if not buildargs.get('csr_csv', None):
             buildargs['csr_csv'] = os.path.join(testdir, "csr.csv")
 
+        if not buildargs.get('csr_json', None):
+            buildargs['csr_json'] = os.path.join(testdir, "csr.json")
+
         builder = Builder(soc, **buildargs)
         if not args.no_compile_firmware or args.override_firmware:
             builder.add_software_package("uip", "{}/firmware/uip".format(os.getcwd()))

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -186,32 +186,75 @@ fi
 export CROSS_COMPILE=${CPU_ARCH}-linux-musl-
 
 TARGET_LINUX_BUILD_DIR=$(dirname $TOP_DIR/$FIRMWARE_FILEBASE)
-(
-	cd $LINUX_SRC
-	echo "Building Linux in $TARGET_LINUX_BUILD_DIR"
-	mkdir -p $TARGET_LINUX_BUILD_DIR
 
-	if [ ! -e $TARGET_LINUX_BUILD_DIR/$ROOTFS ]; then
-		wget $ROOTFS_LOCATION/$ROOTFS -O $TARGET_LINUX_BUILD_DIR/$ROOTFS
-	fi
-
-	if [ ${CPU} = mor1kx ]; then
-		KERNEL_BINARY=vmlinux.bin
-		make O="$TARGET_LINUX_BUILD_DIR" litex_defconfig
-	elif [ ${CPU} = vexriscv ]; then
-		if [ ! -f $TARGET_LINUX_BUILD_DIR/.config ]; then
-			wget ${ROOTFS_LOCATION}/litex_vexriscv_linux.config -O $TARGET_LINUX_BUILD_DIR/.config
+BD_REMOTE="${BD_REMOTE:-https://github.com/buildroot/buildroot.git}"
+BD_SRC="$TOP_DIR/third_party/buildroot"
+LLV_REMOTE="${LLV_REMOTE:-https://github.com/litex-hub/linux-on-litex-vexriscv.git}"
+LLV_SRC="$TOP_DIR/third_party/linux-on-litex-vexriscv"
+if [ ${CPU} = vexriscv ] && [ ${BUILD_BUILDROOT} = 1 ]; then
+	(
+		if [ ! -d "$BD_SRC" ]; then
+		(
+			cd $(dirname $BD_SRC)
+			echo "Downloading Buildroot code."
+			git clone $BD_REMOTE $BD_SRC
+		)
 		fi
 
-		if [ ! -f $TARGET_LINUX_BUILD_DIR/rv32.dtb ]; then
-			wget ${ROOTFS_LOCATION}/rv32.dtb -O $TARGET_LINUX_BUILD_DIR/rv32.dtb
+		if [ ! -d "$LLV_SRC" ]; then
+		(
+			cd $(dirname $LLV_SRC)
+			echo "Downloading Linux on LiteX-VexRiscv code."
+			git clone $LLV_REMOTE $LLV_SRC
+		)
 		fi
 
-		KERNEL_BINARY=Image
-		make O="$TARGET_LINUX_BUILD_DIR" olddefconfig
-	fi
+		GENERATED_JSON="$TARGET_BUILD_DIR/test/csr.json"
+		if [ ! -f "$GENERATED_JSON" ]; then
+			make firmware
+		fi
 
-	time make O="$TARGET_LINUX_BUILD_DIR" -j$JOBS
-	ls -l $TARGET_LINUX_BUILD_DIR/arch/${ARCH}/boot/${KERNEL_BINARY}
-	ln -sf $TARGET_LINUX_BUILD_DIR/arch/${ARCH}/boot/${KERNEL_BINARY} $TOP_DIR/$FIRMWARE_FILEBASE.bin
-)
+		echo "Building Linux on LiteX-VexRiscv in $TARGET_LINUX_BUILD_DIR"
+		mkdir -p $TARGET_LINUX_BUILD_DIR
+
+		$LLV_SRC/json2dts.py $GENERATED_JSON > $TARGET_LINUX_BUILD_DIR/rv32.dts
+		dtc -I dts -O dtb -o $TARGET_LINUX_BUILD_DIR/rv32.dtb $TARGET_LINUX_BUILD_DIR/rv32.dts
+
+		cd $BD_SRC
+		make BR2_EXTERNAL=$LLV_SRC/buildroot/ litex_vexriscv_defconfig
+		time make
+		ls -l $BD_SRC/output/images/
+		ln -sf $BD_SRC/output/images/Image $TOP_DIR/$FIRMWARE_FILEBASE.bin
+		ln -sf $BD_SRC/output/images/rootfs.cpio $TARGET_LINUX_BUILD_DIR/$ROOTFS
+	)
+else
+	(
+		cd $LINUX_SRC
+		echo "Building Linux in $TARGET_LINUX_BUILD_DIR"
+		mkdir -p $TARGET_LINUX_BUILD_DIR
+
+		if [ ! -e $TARGET_LINUX_BUILD_DIR/$ROOTFS ]; then
+			wget $ROOTFS_LOCATION/$ROOTFS -O $TARGET_LINUX_BUILD_DIR/$ROOTFS
+		fi
+
+		if [ ${CPU} = mor1kx ]; then
+			KERNEL_BINARY=vmlinux.bin
+			make O="$TARGET_LINUX_BUILD_DIR" litex_defconfig
+		elif [ ${CPU} = vexriscv ]; then
+			if [ ! -f $TARGET_LINUX_BUILD_DIR/.config ]; then
+				wget ${ROOTFS_LOCATION}/litex_vexriscv_linux.config -O $TARGET_LINUX_BUILD_DIR/.config
+			fi
+
+			if [ ! -f $TARGET_LINUX_BUILD_DIR/rv32.dtb ]; then
+				wget ${ROOTFS_LOCATION}/rv32.dtb -O $TARGET_LINUX_BUILD_DIR/rv32.dtb
+			fi
+
+			KERNEL_BINARY=Image
+			make O="$TARGET_LINUX_BUILD_DIR" olddefconfig
+		fi
+
+		time make O="$TARGET_LINUX_BUILD_DIR" -j$JOBS
+		ls -l $TARGET_LINUX_BUILD_DIR/arch/${ARCH}/boot/${KERNEL_BINARY}
+		ln -sf $TARGET_LINUX_BUILD_DIR/arch/${ARCH}/boot/${KERNEL_BINARY} $TOP_DIR/$FIRMWARE_FILEBASE.bin
+	)
+fi


### PR DESCRIPTION
Currently the script uses prebuilt rootfs and devicetree for VexRiscv configuration, this PR aims to add option to build Linux using Buildroot from [linux-on-litex-vexriscv](https://github.com/litex-hub/linux-on-litex-vexriscv).
This also fixes the issue with LiteX configuration not matching the prebuilt devicetree which for example surfaced in #223 where board has 64MiB of DRAM but devicetree specifies only 32MiB

By default the old method of building Linux is used, to use Buildroot first export `BUILD_BUILDROOT=1`