### PR TITLE
Renode fixes

### DIFF
--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -163,7 +163,6 @@ if [ ${CPU} = vexriscv ]; then
 		EMULATOR_RAM_BASE_ADDRESS=$(parse_generated_header "mem.h" EMULATOR_RAM_BASE)
 		RAM_BASE_ADDRESS=$(parse_generated_header "mem.h" MAIN_RAM_BASE)
 		# get rid of 'L' suffix
-		# passing address without shadow bit causes linux not to boot
 		RAM_BASE_ADDRESS=${RAM_BASE_ADDRESS::-1}
 	 	EMULATOR_RAM_BASE_ADDRESS=${EMULATOR_RAM_BASE_ADDRESS::-1}
 

--- a/scripts/build-renode.sh
+++ b/scripts/build-renode.sh
@@ -27,6 +27,7 @@ fi
 if ! $RENODE_FOUND; then
 	# Download prebuilt renode Release if none is currently installed
 	conda install -c antmicro -c conda-forge renode
+	RENODE_BIN=$CONDA_PREFIX/bin/renode
 fi
 
 case $CPU in

--- a/targets/arty/base.py
+++ b/targets/arty/base.py
@@ -173,6 +173,7 @@ class BaseSoC(SoCSDRAM):
 
         bios_size = 0x8000
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
 
         # sdram
         sdram_module = MT41K128M16(self.clk_freq, "1:4")

--- a/targets/atlys/base.py
+++ b/targets/atlys/base.py
@@ -215,6 +215,7 @@ class BaseSoC(SoCSDRAM):
 
         bios_size = 0x8000
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
 
         #self.submodules.cas = cas.ControlAndStatus(platform, clk_freq)
 

--- a/targets/ice40_hx8k_b_evn/base.py
+++ b/targets/ice40_hx8k_b_evn/base.py
@@ -89,6 +89,7 @@ class BaseSoC(SoCCore):
             "rom", kwargs['cpu_reset_address'], bios_size,
             type="cached+linker")
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
 
         # We don't have a DRAM, so use the remaining SPI flash for user
         # program.

--- a/targets/ice40_up5k_b_evn/base.py
+++ b/targets/ice40_up5k_b_evn/base.py
@@ -104,6 +104,7 @@ class BaseSoC(SoCCore):
             "rom", kwargs['cpu_reset_address'], bios_size,
             type="cached+linker")
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
 
         # SPRAM- UP5K has single port RAM, might as well use it as SRAM to
         # free up scarce block RAM.

--- a/targets/icebreaker/base.py
+++ b/targets/icebreaker/base.py
@@ -116,6 +116,7 @@ class BaseSoC(SoCCore):
             "rom", kwargs['cpu_reset_address'], bios_size,
             type="cached+linker")
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
 
         # SPRAM- UP5K has single port RAM, might as well use it as SRAM to
         # free up scarce block RAM.

--- a/targets/icefun/base.py
+++ b/targets/icefun/base.py
@@ -89,6 +89,7 @@ class BaseSoC(SoCCore):
             "rom", kwargs['cpu_reset_address'], bios_size,
             type="cached+linker")
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
 
         # We don't have a DRAM, so use the remaining SPI flash for user
         # program.

--- a/targets/mimasv2/base.py
+++ b/targets/mimasv2/base.py
@@ -226,6 +226,7 @@ class BaseSoC(SoCSDRAM):
             "rom", kwargs['cpu_reset_address'], bios_size,
             type="cached+linker")
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
 
         # sdram
         sdram_module = MT46H32M16(self.clk_freq, "1:2")

--- a/targets/minispartan6/base.py
+++ b/targets/minispartan6/base.py
@@ -109,6 +109,7 @@ class BaseSoC(SoCSDRAM):
         self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
         self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
         self.register_mem("spiflash", self.mem_map["spiflash"],
             self.spiflash.bus, size=platform.spiflash_total_size)
 

--- a/targets/opsis/base.py
+++ b/targets/opsis/base.py
@@ -274,6 +274,7 @@ class BaseSoC(SoCSDRAM):
 
         bios_size = 0x8000
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
 
         # front panel (ATX)
         self.submodules.front_panel = FrontPanelGPIO(platform, clk_freq)

--- a/targets/pipistrello/base.py
+++ b/targets/pipistrello/base.py
@@ -213,6 +213,7 @@ class BaseSoC(SoCSDRAM):
 
         bios_size = 0x8000
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
         # sdram
         sdram_module = MT46H32M16(self.clk_freq, "1:2")
         self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(

--- a/targets/sim/base.py
+++ b/targets/sim/base.py
@@ -50,6 +50,7 @@ class BaseSoC(SoCSDRAM):
         self.submodules.firmware_ram = firmware.FirmwareROM(firmware_ram_size, firmware_filename)
         self.register_mem("firmware_ram", self.mem_map["firmware_ram"], self.firmware_ram.bus, firmware_ram_size)
         self.flash_boot_address = self.mem_map["firmware_ram"]
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
 
         # sdram
         sdram_module = IS42S16160(self.clk_freq, "1:1")

--- a/targets/tinyfpga_bx/base.py
+++ b/targets/tinyfpga_bx/base.py
@@ -99,6 +99,7 @@ class BaseSoC(SoCCore):
             "rom", kwargs['cpu_reset_address'], bios_size,
             type="cached+linker")
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size+platform.bootloader_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
 
         # We don't have a DRAM, so use the remaining SPI flash for user
         # program.

--- a/targets/upduino_v1/base.py
+++ b/targets/upduino_v1/base.py
@@ -90,6 +90,7 @@ class BaseSoC(SoCCore):
             "rom", kwargs['cpu_reset_address'], bios_size,
             type="cached+linker")
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
 
         # SPRAM- UP5K has single port RAM, might as well use it as SRAM to
         # free up scarce block RAM.


### PR DESCRIPTION
This PR contains separate (unrelated) commits:
* remove an obsolete and possibly misleading comment (minor fix);
* restore generation of `flash_boot_address` constant;
     It's required by Renode to load firmware binary to a proper offset in flash. It has been previously generated by `litex`, but it is no more after bumping to the newest version.
* use proper path to conda-provided Renode