### PR TITLE
[FIX] scripts: Use python package for MimasV2Config

### DIFF
--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -457,16 +457,11 @@ if [ "$PLATFORM" = "opsis" -o "$PLATFORM" = "atlys" ]; then
 fi
 
 # FIXME: Remove this once @jimmo has finished his new firmware
-# MimasV2Config.py
+# MimasV2Config
 if [ "$PLATFORM" = "mimasv2" ]; then
-	MIMASV2CONFIG=$BUILD_DIR/conda/bin/MimasV2Config.py
 	echo
-	echo "Installing MimasV2Config.py (mimasv2 flashing tool)"
-	if [ ! -e $MIMASV2CONFIG ]; then
-		wget https://raw.githubusercontent.com/numato/samplecode/master/FPGA/MimasV2/tools/configuration/python/MimasV2Config.py -O $MIMASV2CONFIG
-		chmod a+x $MIMASV2CONFIG
-	fi
-	check_exists MimasV2Config.py
+	echo "Installing MimasV2Config (mimasv2 flashing tool)"
+        pip install 'git+https://github.com/numato/samplecode/#egg=MimasV2&subdirectory=FPGA/MimasV2/tools/configuration/python/' 
 fi
 
 # flterm

--- a/scripts/enter-env.sh
+++ b/scripts/enter-env.sh
@@ -379,18 +379,6 @@ if [ "$PLATFORM" = "opsis" -o "$PLATFORM" = "atlys" ]; then
 	check_exists fxload || return 1
 fi
 
-# FIXME: Remove this once @jimmo has finished his new firmware
-# MimasV2Config.py
-if [ "$PLATFORM" = "mimasv2" ]; then
-	MIMASV2CONFIG=$BUILD_DIR/conda/bin/MimasV2Config.py
-
-
-
-
-
-
-	check_exists MimasV2Config.py || return 1
-fi
 
 # flterm
 
@@ -492,6 +480,14 @@ check_import_version hexfile $HEXFILE_VERSION || return 1
 
 
 check_import_version hdmi2usb.modeswitch $HDMI2USB_MODESWITCH_VERSION || return 1
+
+# FIXME: Remove this once @jimmo has finished his new firmware
+# MimasV2.Config
+if [ "$PLATFORM" = "mimasv2" ]; then
+        # MimasV2.Config for flashing binaries
+
+        check_import MimasV2.Config || return 1
+fi
 
 if [ "$FIRMWARE" = "zephyr" ]; then
 	# yaml for parsing configuration in Zephyr SDK

--- a/targets/mimasv2/Makefile.mk
+++ b/targets/mimasv2/Makefile.mk
@@ -22,7 +22,7 @@ endif
 
 # Image
 image-flash-$(PLATFORM):
-	$(PYTHON) $$(which MimasV2Config.py) $(PROG_PORT) $(IMAGE_FILE)
+	$(PYTHON) -m MimasV2.Config $(PROG_PORT) $(IMAGE_FILE)
 
 # Gateware
 gateware-load-$(PLATFORM):
@@ -40,7 +40,7 @@ gateware-load-$(PLATFORM):
 GATEWARE_BIOS_FILE = $(TARGET_BUILD_DIR)/image-gateware+bios+none.bin
 
 gateware-flash-$(PLATFORM): $(GATEWARE_BIOS_FILE)
-	$(PYTHON) $$(which MimasV2Config.py) $(PROG_PORT) $(GATEWARE_BIOS_FILE)
+	$(PYTHON) -m MimasV2.Config $(PROG_PORT) $(GATEWARE_BIOS_FILE)
 
 # To avoid duplicating the mkimage.py call here, if the user has not
 # already built a image-gateware+bios+none.bin, we call make recursively


### PR DESCRIPTION
Currently all scripts use local copy of MimasV2 config tool obtained by wget. This PR use python package to deliver this tool, which allows it to be used as python module.
This should me merged as soon as PR: https://github.com/numato/samplecode/pull/45 is merged.
After that old method of providing the tool will fail.