### PR TITLE
shadow_base was replaced by base_address

### DIFF
--- a/targets/netv2/hdmi2pcie.py
+++ b/targets/netv2/hdmi2pcie.py
@@ -78,7 +78,7 @@ class HDMI2PCIeSoC(BaseSoC):
         self.submodules.pcie_endpoint = LitePCIeEndpoint(self.pcie_phy)
 
         # pcie wishbone bridge
-        self.submodules.pcie_bridge = LitePCIeWishboneBridge(self.pcie_endpoint, lambda a: 1, shadow_base=0x40000000)
+        self.submodules.pcie_bridge = LitePCIeWishboneBridge(self.pcie_endpoint, lambda a: 1, base_address=0x40000000)
         self.submodules.wb_swap = WishboneEndianSwap(self.pcie_bridge.wishbone)
         self.add_wb_master(self.wb_swap.wishbone)
 


### PR DESCRIPTION
I *assume* this is the right change, following enjoy-digital/litepcie@000e79e11c7ac9883eaa7a10e46be9bd1deae227.

It generates, but doesn't build on the NeTV2, due to resource limits.