### PR TITLE
WIP -- Modernize platforms + target files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "third_party/nmigen"]
 	path = third_party/nmigen
 	url = https://github.com/m-labs/nmigen.git
+[submodule "third_party/litex-boards"]
+	path = third_party/litex-boards
+	url = https://github.com/litex-hub/litex-boards

--- a/Makefile
+++ b/Makefile
@@ -203,8 +203,13 @@ ifeq ($(FIRMWARE),none)
 OVERRIDE_FIRMWARE=--override-firmware=none
 FIRMWARE_FBI=
 else
+ifeq ($(FIRMWARE),clear)
+OVERRIDE_FIRMWARE=--override-firmware=clear
+FIRMWARE_FBI=
+else
 OVERRIDE_FIRMWARE=--override-firmware=$(FIRMWARE_FILEBASE).fbi
 FIRMWARE_FBI=$(FIRMWARE_FILEBASE).fbi
+endif
 endif
 
 $(IMAGE_FILE): $(GATEWARE_FILEBASE).bin $(BIOS_FILE) $(FIRMWARE_FBI)

--- a/gateware/info/__init__.py
+++ b/gateware/info/__init__.py
@@ -14,11 +14,12 @@ from gateware.info import platform as platform_info
 
 class Info(Module, AutoCSR):
     def __init__(self, platform, target_name):
-        self.submodules.dna = dna.DNA()
         self.submodules.git = git.GitInfo()
         target = target_name.lower()[:-3]
         self.submodules.platform = platform_info.PlatformInfo(platform.name, target)
 
+        if "xc" in platform.device:
+            self.submodules.dna = dna.DNA()
         if "xc7" in platform.device:
             self.submodules.xadc = xadc.XADC()
 

--- a/mkimage.py
+++ b/mkimage.py
@@ -8,6 +8,102 @@ import argparse
 
 import make
 
+from collections import namedtuple
+
+
+def round(i):
+    return int(i / 4) * 4
+
+
+_Region = namedtuple("Region", ["name", "desc", "start", "size"])
+class Region(_Region):
+    def __init__(self, name, desc, start, size):
+        #_Region.__init__(self, name, start, size, desc)
+        assert round(start) == start, (
+            "Start invalid {} != {}".format(start, round(start)))
+        assert round(size) == size, (
+            "Size invalid {} != {}".format(size, round(size)))
+
+    def __str__(self):
+        return "Region(0x{:06x}, 0x{:06x}, {:10s}, {})".format(
+            self.start, self.end, repr(self.name), repr(self.desc))
+
+    @property
+    def end(self):
+        return self.start + self.size
+
+
+def get_regions(size_gw, size_bios, size_flash):
+    """
+
+    >>> regions = get_regions(256, 128, 1000)
+    >>> for r in regions:
+    ...     print(r)
+    Region(0x000000, 0x000100, 'Gateware', 'FPGA bitstream')
+    Region(0x000100, 0x000180, 'BIOS'    , 'LiteX BIOS with CRC')
+    Region(0x000180, 0x0003e8, 'Firmware', 'Firmware in FBI format')
+
+    """
+    region_gw = Region(
+        "Gateware",
+        "FPGA bitstream",
+        0,
+        round(size_gw),
+    )
+    region_bios = Region(
+        "BIOS",
+        "LiteX BIOS with CRC",
+        region_gw.end,
+        size_bios,
+    )
+    size_fw = round(size_flash - region_bios.end)
+    region_fw = Region(
+        "Firmware",
+        "Firmware in FBI format",
+        region_bios.end,
+        size_fw,
+    )
+    return [region_gw, region_bios, region_fw]
+
+
+def fill_region(image_fileobj, region, input_filename, fill_zero=False):
+    """
+
+    Output;
+    -----
+    Gateware @ 0x00000000 (using      135100 bytes of     163840 bytes) build/ice40_hx8k_b_evn_base_vexriscv.minimal+debug//gateware/top.bin - FPGA Bitstream
+    ff 00 00 ff 7e aa 99 7e 51 00 01 05 92 00 21 62 03 67 72 01 10 82 00 00 11 00 01 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+    -----
+
+    {name  } @ {start   } (using {input_len} bytes of {length  } bytes) {input_fn} - {desc}
+    {hex file data}
+    """
+
+    if inputfile:
+        input_data   = open(input_filename, "rb").read()
+        input_size   = len(input_data)
+        input_result = "Loaded from {}".format(input_filename)
+    else:
+        input_data   = b""
+        input_size   = len(input_data)
+        input_result = "Skipped"
+
+    #   "{name:08s} @ 0x{start:08x} "
+    #   "(using {input_size:10} bytes of {:10} bytes - {:02.2)%) {:60s} - {}"
+
+    #print(
+    #    "{:08s} @ 0x{:08x} (using {:10} bytes of {:10} bytes - {:02.2)% {:60s} - {}"
+    #).format()
+
+    print(" ".join("{:02x}".format(i) for i in input_data[:64]))
+    assert input_size < region.size
+    assert f.tell() < region.start, "{} < {}".format(f.tell(), region.start)
+    f.seek(region.start)
+    f.write(input_data)
+    if fill_zero:
+        while f.tell() < region.end:
+            f.write('\0')
+
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
@@ -56,8 +152,9 @@ def main():
 
     firmware = make.get_firmware(builddir, "flash")
     if args.override_firmware:
-        if args.override_firmware.lower() == "none":
+        if args.override_firmware.lower() in ("none", "clear"):
             firmware = None
+            args.firmware_name = args.override_firmware
         else:
             firmware = args.override_firmware
     if firmware:
@@ -75,6 +172,10 @@ def main():
     bios_pos = platform.gateware_size
     firmware_pos = platform.gateware_size + bios_size
 
+    flash_size = platform.spiflash_total_size
+    if args.force_image_size and args.force_image_size.lower() not in ("true", "1"):
+            flash_size = int(args.force_image_size)
+
     print()
     with open(output_file, "wb") as f:
         # FPGA gateware
@@ -84,9 +185,13 @@ def main():
             gateware_data = b""
             gateware = "Skipped"
 
-        print(("Gateware @ 0x{:08x} ({:10} bytes) {:60}"
+        print(("Gateware @ 0x{:08x} (using {:10} bytes of {:10} bytes) {:60}"
                " - FPGA Bitstream"
-               ).format(gateware_pos, len(gateware_data), gateware))
+               ).format(
+                   gateware_pos,
+                   len(gateware_data),
+                   bios_pos - gateware_pos,
+                   gateware))
         print(" ".join("{:02x}".format(i) for i in gateware_data[:64]))
         assert len(gateware_data) < platform.gateware_size
         f.seek(0)
@@ -102,22 +207,31 @@ def main():
         assert len(bios_data) < bios_size
         f.seek(bios_pos)
         f.write(bios_data)
-        print(("    BIOS @ 0x{:08x} ({:10} bytes) {:60}"
+        print(("    BIOS @ 0x{:08x} (using {:10} bytes of {:10} bytes) {:60}"
                " - LiteX BIOS with CRC"
-               ).format(bios_pos, len(bios_data), bios))
+               ).format(
+                   bios_pos,
+                   len(bios_data),
+                   firmware_pos - bios_pos,
+                   bios))
         print(" ".join("{:02x}".format(i) for i in bios_data[:64]))
 
         if firmware:
             firmware_data = open(firmware, "rb").read()
         else:
-            firmware_data = b""
-            firmware = "Skipped"
+            firmware_data = b"\xff\xff\xff\xff"
+            firmware = "Cleared"
+            #firmware_data = b""
+            #firmware = "Skipped"
 
         # SoftCPU firmware
-        print(("Firmware @ 0x{:08x} ({:10} bytes) {:60}"
+        print(("Firmware @ 0x{:08x} (using {:10} bytes of {:10} bytes) {:60}"
                " - {} Firmware in FBI format (loaded into DRAM)"
                ).format(
-                   firmware_pos, len(firmware_data), firmware,
+                   firmware_pos,
+                   len(firmware_data),
+                   flash_size - firmware_pos,
+                   firmware,
                    args.firmware_name))
         print(" ".join("{:02x}".format(i) for i in firmware_data[:64]))
         f.seek(firmware_pos)
@@ -136,10 +250,6 @@ def main():
                ).format(total, int(total*8/1024/1024), total/1024/1024))
 
         if args.force_image_size:
-            if args.force_image_size.lower() in ("true", "1"):
-                flash_size = platform.spiflash_total_size
-            else:
-                flash_size = int(args.force_image_size)
             f.write(b'\xff' * (flash_size - f.tell()))
 
     print()
@@ -149,4 +259,6 @@ def main():
 
 
 if __name__ == "__main__":
+    import doctest
+    doctest.testmod()
     main()

--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -655,13 +655,14 @@ echo "-----------------------"
 # lite
 for LITE in $LITE_REPOS; do
 	LITE_DIR=$THIRD_DIR/$LITE
+	LITE_MOD=$(echo $LITE | sed -e's/-/_/g')
 	(
 		echo
 		cd $LITE_DIR
 		echo "Installing $LITE from $LITE_DIR (local python module)"
 		python setup.py develop
 	)
-	check_import $LITE
+	check_import $LITE_MOD
 done
 
 echo "-----------------------"

--- a/scripts/enter-env.sh
+++ b/scripts/enter-env.sh
@@ -567,14 +567,15 @@ echo "-----------------------"
 
 # lite
 for LITE in $LITE_REPOS; do
+	LITE_DIR=$THIRD_DIR/$LITE
+	LITE_MOD=$(echo $LITE | sed -e's/-/_/g')
 
 
 
 
 
 
-
-	check_import $LITE || return 1
+	check_import $LITE_MOD || return 1
 done
 
 echo "-----------------------"

--- a/scripts/settings.sh
+++ b/scripts/settings.sh
@@ -27,6 +27,7 @@ LITE_REPOS="
 	migen
 	nmigen
 	litex
+	litex-boards
 	litedram
 	liteeth
 	litepcie

--- a/targets/arty/base.py
+++ b/targets/arty/base.py
@@ -1,194 +1,103 @@
 # Support for the Digilent Arty Board
 from migen import *
-from migen.genlib.resetsync import AsyncResetSynchronizer
 
-from litex.soc.integration.soc_core import mem_decoder
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
 from litex.soc.interconnect import wishbone
 
 from litedram.modules import MT41K128M16
-from litedram.phy import a7ddrphy
-from litedram.core import ControllerSettings
+from litedram.phy import s7ddrphy
 
 from gateware import cas
 from gateware import info
-from gateware import led
 from gateware import spi_flash
 
-from targets.utils import csr_map_update, period_ns
-
-
-class _CRG(Module):
-    def __init__(self, platform):
-        self.clock_domains.cd_sys = ClockDomain()
-        self.clock_domains.cd_sys4x = ClockDomain(reset_less=True)
-        self.clock_domains.cd_sys4x_dqs = ClockDomain(reset_less=True)
-        self.clock_domains.cd_clk200 = ClockDomain()
-        self.clock_domains.cd_clk100 = ClockDomain()
-        self.clock_domains.cd_clk50 = ClockDomain()
-
-        clk100 = platform.request("clk100")
-        rst = ~platform.request("cpu_reset")
-
-        pll_locked = Signal()
-        pll_fb = Signal()
-        self.pll_sys = Signal()
-        pll_sys4x = Signal()
-        pll_sys4x_dqs = Signal()
-        pll_clk200 = Signal()
-        pll_clk100 = Signal()
-        pll_clk50 = Signal()
-        self.specials += [
-            Instance("PLLE2_BASE",
-                     p_STARTUP_WAIT="FALSE", o_LOCKED=pll_locked,
-
-                     # VCO @ 1600 MHz
-                     p_REF_JITTER1=0.01, p_CLKIN1_PERIOD=10.0,
-                     p_CLKFBOUT_MULT=16, p_DIVCLK_DIVIDE=1,
-                     i_CLKIN1=clk100, i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb,
-
-                     # 100 MHz
-                     p_CLKOUT0_DIVIDE=16, p_CLKOUT0_PHASE=0.0,
-                     o_CLKOUT0=self.pll_sys,
-
-                     # 400 MHz
-                     p_CLKOUT1_DIVIDE=4, p_CLKOUT1_PHASE=0.0,
-                     o_CLKOUT1=pll_sys4x,
-
-                     # 400 MHz dqs
-                     p_CLKOUT2_DIVIDE=4, p_CLKOUT2_PHASE=90.0,
-                     o_CLKOUT2=pll_sys4x_dqs,
-
-                     # 200 MHz
-                     p_CLKOUT3_DIVIDE=8, p_CLKOUT3_PHASE=0.0,
-                     o_CLKOUT3=pll_clk200,
-
-                     # 50MHz
-                     p_CLKOUT4_DIVIDE=32, p_CLKOUT4_PHASE=0.0,
-                     o_CLKOUT4=pll_clk50,
-
-                     # 100MHz
-                     p_CLKOUT5_DIVIDE=16, p_CLKOUT5_PHASE=0.0,
-                     o_CLKOUT5=pll_clk100
-            ),
-            Instance("BUFG", i_I=self.pll_sys, o_O=self.cd_sys.clk),
-            Instance("BUFG", i_I=pll_sys4x, o_O=self.cd_sys4x.clk),
-            Instance("BUFG", i_I=pll_sys4x_dqs, o_O=self.cd_sys4x_dqs.clk),
-            Instance("BUFG", i_I=pll_clk200, o_O=self.cd_clk200.clk),
-            Instance("BUFG", i_I=pll_clk100, o_O=self.cd_clk100.clk),
-            Instance("BUFG", i_I=pll_clk50, o_O=self.cd_clk50.clk),
-            AsyncResetSynchronizer(self.cd_sys, ~pll_locked | rst),
-            AsyncResetSynchronizer(self.cd_clk200, ~pll_locked | rst),
-            AsyncResetSynchronizer(self.cd_clk100, ~pll_locked | rst),
-            AsyncResetSynchronizer(self.cd_clk50, ~pll_locked | rst),
-        ]
-
-        reset_counter = Signal(4, reset=15)
-        ic_reset = Signal(reset=1)
-        self.sync.clk200 += \
-            If(reset_counter != 0,
-                reset_counter.eq(reset_counter - 1)
-            ).Else(
-                ic_reset.eq(0)
-            )
-        self.specials += Instance("IDELAYCTRL", i_REFCLK=ClockSignal("clk200"), i_RST=ic_reset)
-
-        # 25MHz clock for Ethernet
-        eth_clk = Signal()
-        self.specials += [
-            Instance("BUFR", p_BUFR_DIVIDE="4", i_CE=1, i_CLR=0, i_I=clk100, o_O=eth_clk),
-            Instance("BUFG", i_I=eth_clk, o_O=platform.request("eth_ref_clk")),
-        ]
+from .crg import _CRG
 
 
 class BaseSoC(SoCSDRAM):
-    csr_peripherals = (
-        "spiflash",
-        "ddrphy",
-        "info",
-        "cas",
-#        "leds",
-#        "rgb_leds",
-    )
-    csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
-
-    SoCSDRAM.mem_map = {
-        "rom":      0x00000000,
-        "sram":     0x10000000,
-        "main_ram": 0x40000000,
-        "csr":      0xe0000000,
-    }
-
-    mem_map = {
-        "spiflash": 0x20000000,
-        "emulator_ram": 0x50000000,
-    }
-    mem_map.update(SoCSDRAM.mem_map)
+    mem_map = {**SoCSDRAM.mem_map, **{
+        'spiflash': 0x20000000,
+    }}
 
     def __init__(self, platform, spiflash="spiflash_1x", **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0x8000
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x8000
+        kwargs['integrated_rom_size']=0x8000
+        kwargs['integrated_sram_size']=0x8000
 
-        clk_freq = int(100e6)
-        SoCSDRAM.__init__(self, platform, clk_freq, **kwargs)
+        sys_clk_freq = int(100e6)
+        # SoCSDRAM ---------------------------------------------------------------------------------
+        SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq, **kwargs)
 
-        self.submodules.crg = _CRG(platform)
-        self.crg.cd_sys.clk.attr.add("keep")
-        self.platform.add_period_constraint(self.crg.cd_sys.clk, period_ns(clk_freq))
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/sys_clk_freq)
 
-        # Basic peripherals
+        # DDR3 SDRAM -------------------------------------------------------------------------------
+        if True:
+            sdram_module = MT41K128M16(sys_clk_freq, "1:4")
+            self.submodules.ddrphy = s7ddrphy.A7DDRPHY(
+                platform.request("ddram"),
+                memtype      = sdram_module.memtype,
+                nphases      = 4,
+                sys_clk_freq = sys_clk_freq)
+            self.add_csr("ddrphy")
+            self.register_sdram(
+                self.ddrphy,
+                geom_settings   = sdram_module.geom_settings,
+                timing_settings = sdram_module.timing_settings)
+
+        # Basic peripherals ------------------------------------------------------------------------
         self.submodules.info = info.Info(platform, self.__class__.__name__)
-        self.submodules.cas = cas.ControlAndStatus(platform, clk_freq)
-#        self.submodules.leds = led.ClassicLed(Cat(platform.request("user_led", i) for i in range(4)))
-#        self.submodules.rgb_leds = led.RGBLed(platform.request("rgb_leds"))
+        self.add_csr("info")
+        self.submodules.cas = cas.ControlAndStatus(platform, sys_clk_freq)
+        self.add_csr("cas")
 
-        # spi flash
+        # Add debug interface if the CPU has one ---------------------------------------------------
+        if hasattr(self.cpu, "debug_bus"):
+            self.register_mem(
+                name="vexriscv_debug",
+                address=0xf00f0000,
+                interface=self.cpu.debug_bus,
+                size=0x100)
+
+        # Memory mapped SPI Flash ------------------------------------------------------------------
         spiflash_pads = platform.request(spiflash)
         spiflash_pads.clk = Signal()
-        self.specials += Instance("STARTUPE2",
-                                  i_CLK=0, i_GSR=0, i_GTS=0, i_KEYCLEARB=0, i_PACK=0,
-                                  i_USRCCLKO=spiflash_pads.clk, i_USRCCLKTS=0, i_USRDONEO=1, i_USRDONETS=1)
+        self.specials += Instance(
+            "STARTUPE2",
+            i_CLK=0, i_GSR=0, i_GTS=0, i_KEYCLEARB=0, i_PACK=0,
+            i_USRCCLKO=spiflash_pads.clk, i_USRCCLKTS=0, i_USRDONEO=1, i_USRDONETS=1)
         spiflash_dummy = {
             "spiflash_1x": 9,
             "spiflash_4x": 11,
         }
         self.submodules.spiflash = spi_flash.SpiFlash(
-                spiflash_pads,
-                dummy=spiflash_dummy[spiflash],
-                div=platform.spiflash_clock_div,
-                endianness=self.cpu.endianness)
-        self.add_constant("SPIFLASH_PAGE_SIZE", 256)
-        self.add_constant("SPIFLASH_SECTOR_SIZE", 0x10000)
-        self.add_wb_slave(mem_decoder(self.mem_map["spiflash"]), self.spiflash.bus)
+            spiflash_pads,
+            dummy=spiflash_dummy[spiflash],
+            div=platform.spiflash_clock_div,
+            endianness=self.cpu.endianness)
+        self.add_csr("spiflash")
+        self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
+        self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
+        self.add_constant("SPIFLASH_TOTAL_SIZE", platform.spiflash_total_size)
+        self.add_wb_slave(
+            self.mem_map["spiflash"],
+            self.spiflash.bus,
+            platform.spiflash_total_size)
         self.add_memory_region(
-            "spiflash", self.mem_map["spiflash"], 16*1024*1024)
-
-        if self.cpu_type == "vexriscv" and self.cpu_variant == "linux":
-            size = 0x4000
-            self.submodules.emulator_ram = wishbone.SRAM(size)
-            self.register_mem("emulator_ram", self.mem_map["emulator_ram"], self.emulator_ram.bus, size)
+            "spiflash",
+            self.mem_map["spiflash"],
+            platform.spiflash_total_size)
 
         bios_size = 0x8000
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
         self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
 
-        # sdram
-        sdram_module = MT41K128M16(self.clk_freq, "1:4")
-        self.submodules.ddrphy = a7ddrphy.A7DDRPHY(
-            platform.request("ddram"))
-        self.add_constant("READ_LEVELING_BITSLIP", 3)
-        self.add_constant("READ_LEVELING_DELAY", 14)
-        controller_settings = ControllerSettings(
-            with_bandwidth=True,
-            cmd_buffer_depth=8,
-            with_refresh=True)
-        self.register_sdram(self.ddrphy,
-                            sdram_module.geom_settings,
-                            sdram_module.timing_settings,
-                            controller_settings=controller_settings)
+        # Support for soft-emulation for full Linux support ----------------------------------------
+        if self.cpu_type == "vexriscv" and self.cpu_variant == "linux":
+            size = 0x4000
+            self.submodules.emulator_ram = wishbone.SRAM(size)
+            self.register_mem("emulator_ram", self.mem_map["emulator_ram"], self.emulator_ram.bus, size)
 
 
 SoC = BaseSoC

--- a/targets/arty/crg.py
+++ b/targets/arty/crg.py
@@ -1,0 +1,30 @@
+# Support for the Digilent Arty Board
+
+from migen import *
+
+from litex.soc.cores.clock import *
+
+# CRG ----------------------------------------------------------------------------------------------
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq):
+        self.clock_domains.cd_sys       = ClockDomain()
+        self.clock_domains.cd_sys4x     = ClockDomain(reset_less=True)
+        self.clock_domains.cd_sys4x_dqs = ClockDomain(reset_less=True)
+        self.clock_domains.cd_clk200    = ClockDomain()
+        self.clock_domains.cd_eth       = ClockDomain()
+
+        # # #
+
+        self.submodules.pll = pll = S7PLL(speedgrade=-1)
+        self.comb += pll.reset.eq(~platform.request("cpu_reset"))
+        pll.register_clkin(platform.request("clk100"), 100e6)
+        pll.create_clkout(self.cd_sys,       sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x,     4*sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x_dqs, 4*sys_clk_freq, phase=90)
+        pll.create_clkout(self.cd_clk200,    200e6)
+        pll.create_clkout(self.cd_eth,       25e6)
+
+        self.submodules.idelayctrl = S7IDELAYCTRL(self.cd_clk200)
+
+        self.comb += platform.request("eth_ref_clk").eq(self.cd_eth.clk)

--- a/targets/arty/etherbone.py
+++ b/targets/arty/etherbone.py
@@ -1,16 +1,17 @@
+from litex.soc.integration.soc_core import mem_decoder
 from litex.soc.integration.soc_sdram import *
 
-from liteeth.core.mac import LiteEthMAC
+from liteeth.common import convert_ip
+from liteeth.core import LiteEthUDPIPCore
+from liteeth.frontend.etherbone import LiteEthEtherbone
+from liteeth.mac import LiteEthMAC
 from liteeth.phy import LiteEthPHY
 
-from .base import BaseSoC
+from targets.utils import csr_map_update
+from targets.arty.base import SoC as BaseSoC
 
 
-class NetSoC(BaseSoC):
-    mem_map = {**BaseSoC.mem_map, **{
-        "ethmac": 0xb0000000,
-    }}
-
+class EtherboneSoC(BaseSoC):
     def __init__(self, platform, *args, **kwargs):
         # Need a larger integrated ROM on or1k to fit the BIOS with TFTP support.
         if 'integrated_rom_size' not in kwargs and kwargs.get('cpu_type', 'lm32') != 'lm32':
@@ -19,23 +20,22 @@ class NetSoC(BaseSoC):
         BaseSoC.__init__(self, platform, *args, **kwargs)
 
         # Ethernet ---------------------------------------------------------------------------------
-        # Ethernet PHY
+        # Ethernet Phy
         self.submodules.ethphy = LiteEthPHY(
-            platform.request("eth_clocks"),
-            platform.request("eth"))
+            clock_pads = self.platform.request("eth_clocks"),
+            pads       = self.platform.request("eth"))
         self.add_csr("ethphy")
-
-        # Ethernet MAC
-        ethmac_win_size = 0x2000
-        self.submodules.ethmac = LiteEthMAC(
-            phy        = self.ethphy,
-            dw         = 32,
-            interface  = "wishbone",
-            endianness = self.cpu.endianness)
-        self.add_wb_slave(self.mem_map["ethmac"], self.ethmac.bus, ethmac_win_size)
-        self.add_memory_region("ethmac", self.mem_map["ethmac"], ethmac_win_size, type="io")
-        self.add_csr("ethmac")
-        self.add_interrupt("ethmac")
+        # Ethernet Core
+        etherbone_mac_address = 0x10e2d5000000
+        etherbone_ip_address  = "192.168.100.50"
+        self.submodules.ethcore = LiteEthUDPIPCore(
+            phy         = self.ethphy,
+            mac_address = etherbone_mac_address,
+            ip_address  = etherbone_ip_address,
+            clk_freq    = self.clk_freq)
+        # Etherbone Core
+        self.submodules.etherbone = LiteEthEtherbone(self.ethcore.udp, 1234)
+        self.add_wb_master(self.etherbone.wishbone.bus)
         # timing constraints
         self.platform.add_period_constraint(self.ethphy.crg.cd_eth_rx.clk, 1e9/25e6)
         self.platform.add_period_constraint(self.ethphy.crg.cd_eth_tx.clk, 1e9/25e6)
@@ -43,6 +43,15 @@ class NetSoC(BaseSoC):
             self.crg.cd_sys.clk,
             self.ethphy.crg.cd_eth_rx.clk,
             self.ethphy.crg.cd_eth_tx.clk)
+
+        # Analyzer ---------------------------------------------------------------------------------
+        #analyzer_signals = [
+        #    # FIXME: find interesting signals to probe
+        #    self.cpu.ibus,
+        #    self.cpu.dbus
+        #]
+        #self.submodules.analyzer = LiteScopeAnalyzer(analyzer_signals, 512)
+        #self.add_csr("analyzer")
 
     def configure_iprange(self, iprange):
         iprange = [int(x) for x in iprange.split(".")]
@@ -60,4 +69,4 @@ class NetSoC(BaseSoC):
             self.add_constant(s, e)
 
 
-SoC = NetSoC
+SoC = EtherboneSoC

--- a/targets/arty/etherbone.py
+++ b/targets/arty/etherbone.py
@@ -7,7 +7,6 @@ from liteeth.frontend.etherbone import LiteEthEtherbone
 from liteeth.mac import LiteEthMAC
 from liteeth.phy import LiteEthPHY
 
-from targets.utils import csr_map_update
 from targets.arty.base import SoC as BaseSoC
 
 

--- a/targets/arty/tf.py
+++ b/targets/arty/tf.py
@@ -1,24 +1,10 @@
 # Support for the Digilent Arty Board
+
 from migen import *
 from migen.genlib.resetsync import AsyncResetSynchronizer
 
-from litex.build.generic_platform import Pins, Subsignal, IOStandard, Misc
-from litex.soc.integration.soc_core import mem_decoder
-from litex.soc.integration.soc_sdram import *
-from litex.soc.integration.builder import *
-from litex.soc.interconnect import wishbone
 from litex.soc.cores.bitbang import I2CMaster
 
-from litedram.modules import MT41K128M16
-from litedram.phy import a7ddrphy
-from litedram.core import ControllerSettings
-
-from gateware import cas
-from gateware import info
-from gateware import led
-from gateware import spi_flash
-
-from targets.utils import csr_map_update, period_ns
 from targets.arty.base import BaseSoC
 
 i2c_pmod_d =  [

--- a/targets/atlys/base.py
+++ b/targets/atlys/base.py
@@ -1,12 +1,10 @@
+#!/usr/bin/env python3
 # Support for the Digilent Atlys board - digilentinc.com/atlys/
-from fractions import Fraction
-
 from migen import *
-from migen.genlib.resetsync import AsyncResetSynchronizer
-from migen.genlib.misc import WaitTimer
 
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
+from litex.soc.interconnect import wishbone
 
 from litedram.modules import P3R1GE4JGF
 from litedram.phy import s6ddrphy
@@ -16,226 +14,92 @@ from litedram.core import ControllerSettings
 from gateware import info
 from gateware import spi_flash
 
-from targets.utils import csr_map_update
-
-
-class _CRG(Module):
-    def __init__(self, platform, clk_freq):
-        # Clock domains for the system (soft CPU and related components run at).
-        self.clock_domains.cd_sys = ClockDomain()
-        # Clock domains for the DDR interface.
-        self.clock_domains.cd_sdram_half = ClockDomain()
-        self.clock_domains.cd_sdram_full_wr = ClockDomain()
-        self.clock_domains.cd_sdram_full_rd = ClockDomain()
-        # Clock domain for peripherals (such as HDMI output).
-        self.clock_domains.cd_base50 = ClockDomain()
-        self.clock_domains.cd_encoder = ClockDomain()
-
-        self.reset = Signal()
-
-        # Input 100MHz clock
-        f0 = 100*1000000
-        clk100 = platform.request("clk100")
-        clk100a = Signal()
-        # Input 100MHz clock (buffered)
-        self.specials += Instance("IBUFG", i_I=clk100, o_O=clk100a)
-        clk100b = Signal()
-        self.specials += Instance(
-            "BUFIO2", p_DIVIDE=1,
-            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
-            i_I=clk100a, o_DIVCLK=clk100b)
-
-        f = Fraction(int(clk_freq), int(f0))
-        n, m = f.denominator, f.numerator
-        assert f0/n*m == clk_freq
-        p = 8
-
-        # Unbuffered output signals from the PLL. They need to be buffered
-        # before feeding into the fabric.
-        unbuf_sdram_full = Signal()
-        unbuf_sdram_half_a = Signal()
-        unbuf_sdram_half_b = Signal()
-        unbuf_encoder = Signal()
-        unbuf_sys = Signal()
-        unbuf_unused = Signal()
-
-        # PLL signals
-        pll_lckd = Signal()
-        pll_fb = Signal()
-        self.specials.pll = Instance(
-            "PLL_ADV",
-            name="crg_pll_adv",
-            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
-            p_REF_JITTER=.01,
-            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
-            p_DIVCLK_DIVIDE=1,
-            # Input Clocks (100MHz)
-            i_CLKIN1=clk100b,
-            p_CLKIN1_PERIOD=1e9/f0,
-            i_CLKIN2=0,
-            p_CLKIN2_PERIOD=0.,
-            i_CLKINSEL=1,
-            # Feedback
-            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
-            p_CLK_FEEDBACK="CLKFBOUT",
-            p_CLKFBOUT_MULT=m*p//n, p_CLKFBOUT_PHASE=0.,
-            # (300MHz) sdram wr rd
-            o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
-            p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//4,
-            # ( 66MHz) encoder
-            o_CLKOUT1=unbuf_encoder, p_CLKOUT1_DUTY_CYCLE=.5,
-            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=9,
-            # (150MHz) sdram_half - sdram dqs adr ctrl
-            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
-            p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=p//2,
-            # (150MHz) off-chip ddr
-            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
-            p_CLKOUT3_PHASE=250., p_CLKOUT3_DIVIDE=p//2,
-            # ( 50MHz) unused? - Was peripheral
-            o_CLKOUT4=unbuf_unused, p_CLKOUT4_DUTY_CYCLE=.5,
-            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=12,
-            # ( 75MHz) sysclk
-            o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
-            p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=p//1,
-        )
-
-
-        # power on reset?
-        reset = ~platform.request("cpu_reset") | self.reset
-        self.clock_domains.cd_por = ClockDomain()
-        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
-        self.sync.por += If(por != 0, por.eq(por - 1))
-        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
-
-        # System clock - 75MHz
-        self.specials += Instance("BUFG", name="sys_bufg", i_I=unbuf_sys, o_O=self.cd_sys.clk)
-        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
-        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
-
-
-        # SDRAM clocks
-        # ------------------------------------------------------------------------------
-        self.clk4x_wr_strb = Signal()
-        self.clk4x_rd_strb = Signal()
-
-        # sdram_full
-        self.specials += Instance("BUFPLL", name="sdram_full_bufpll",
-                                  p_DIVIDE=4,
-                                  i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys.clk,
-                                  i_LOCKED=pll_lckd,
-                                  o_IOCLK=self.cd_sdram_full_wr.clk,
-                                  o_SERDESSTROBE=self.clk4x_wr_strb)
-        self.comb += [
-            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
-            self.clk4x_rd_strb.eq(self.clk4x_wr_strb),
-        ]
-        # sdram_half
-        self.specials += Instance("BUFG", name="sdram_half_a_bufpll", i_I=unbuf_sdram_half_a, o_O=self.cd_sdram_half.clk)
-        clk_sdram_half_shifted = Signal()
-        self.specials += Instance("BUFG", name="sdram_half_b_bufpll", i_I=unbuf_sdram_half_b, o_O=clk_sdram_half_shifted)
-
-        output_clk = Signal()
-        clk = platform.request("ddram_clock")
-        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
-                                  p_INIT=0, p_SRTYPE="SYNC",
-                                  i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
-                                  i_C0=clk_sdram_half_shifted,
-                                  i_C1=~clk_sdram_half_shifted,
-                                  o_Q=output_clk)
-        self.specials += Instance("OBUFDS", i_I=output_clk, o_O=clk.p, o_OB=clk.n)
-
-        # Peripheral clock - 50MHz
-        # ------------------------------------------------------------------------------
-        # The peripheral clock is kept separate from the system clock to allow
-        # the system clock to be increased in the future.
-        dcm_base50_locked = Signal()
-        self.specials += [
-            Instance("DCM_CLKGEN", name="crg_periph_dcm_clkgen",
-                     p_CLKIN_PERIOD=10.0,
-                     p_CLKFX_MULTIPLY=2,
-                     p_CLKFX_DIVIDE=4,
-                     p_CLKFX_MD_MAX=0.5, # CLKFX_MULTIPLY/CLKFX_DIVIDE
-                     p_CLKFXDV_DIVIDE=2,
-                     p_SPREAD_SPECTRUM="NONE",
-                     p_STARTUP_WAIT="FALSE",
-
-                     i_CLKIN=clk100a,
-                     o_CLKFX=self.cd_base50.clk,
-                     o_LOCKED=dcm_base50_locked,
-                     i_FREEZEDCM=0,
-                     i_RST=ResetSignal(),
-                     ),
-            AsyncResetSynchronizer(self.cd_base50,
-                self.cd_sys.rst | ~dcm_base50_locked)
-        ]
-        platform.add_period_constraint(self.cd_base50.clk, 20)
-
-        # Encoder clock - 66 MHz
-        # ------------------------------------------------------------------------------
-        self.specials += Instance("BUFG", name="encoder_bufg", i_I=unbuf_encoder, o_O=self.cd_encoder.clk)
-        self.specials += AsyncResetSynchronizer(self.cd_encoder, self.cd_sys.rst)
+from .crg import _CRG
 
 
 class BaseSoC(SoCSDRAM):
-    csr_peripherals = (
-        "spiflash",
-#        "cas",
-        "ddrphy",
-        "info",
-    )
-    csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
-
-    mem_map = {
-        "spiflash": 0x20000000,  # (default shadow @0xa0000000)
-    }
-    mem_map.update(SoCSDRAM.mem_map)
+    mem_map = {**SoCSDRAM.mem_map, **{
+        'spiflash': 0x20000000,
+    }}
 
     def __init__(self, platform, **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0x8000
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x8000
+        kwargs['integrated_rom_size']=0x8000
+        kwargs['integrated_sram_size']=0x8000
 
-        clk_freq = 75*1000000
-        SoCSDRAM.__init__(self, platform, clk_freq, **kwargs)
+        sys_clk_freq = 75*1000000
+        # SoCSDRAM ---------------------------------------------------------------------------------
+        SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq, **kwargs)
 
-        self.submodules.crg = _CRG(platform, clk_freq)
-        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/clk_freq)
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/sys_clk_freq)
 
+        # DDR2 SDRAM -------------------------------------------------------------------------------
+        if True:
+            sdram_module = P3R1GE4JGF(sys_clk_freq, "1:2")
+            self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
+                platform.request("ddram"),
+                memtype      = sdram_module.memtype,
+                rd_bitslip   = 0,
+                wr_bitslip   = 4,
+                dqs_ddr_alignment="C0")
+            self.add_csr("ddrphy")
+            controller_settings = ControllerSettings(
+                with_bandwidth=True)
+            self.register_sdram(
+                self.ddrphy,
+                geom_settings   = sdram_module.geom_settings,
+                timing_settings = sdram_module.timing_settings,
+                controller_settings=controller_settings)
+            self.comb += [
+                self.ddrphy.clk4x_wr_strb.eq(self.crg.clk4x_wr_strb),
+                self.ddrphy.clk4x_rd_strb.eq(self.crg.clk4x_rd_strb),
+            ]
+
+        # Basic peripherals ------------------------------------------------------------------------
+        # info module
         self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.add_csr("info")
+        # control and status module
+        #self.submodules.cas = cas.ControlAndStatus(platform, sys_clk_freq)
+        self.add_csr("cas")
 
+        # Add debug interface if the CPU has one ---------------------------------------------------
+        if hasattr(self.cpu, "debug_bus"):
+            self.register_mem(
+                name="vexriscv_debug",
+                address=0xf00f0000,
+                interface=self.cpu.debug_bus,
+                size=0x100)
+
+        # Memory mapped SPI Flash ------------------------------------------------------------------
         self.submodules.spiflash = spi_flash.SpiFlash(
             platform.request("spiflash4x"),
             dummy=platform.spiflash_read_dummy_bits,
-            div=platform.spiflash_clock_div)
+            div=platform.spiflash_clock_div,
+            endianness=self.cpu.endianness)
+        self.add_csr("spiflash")
         self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
         self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
-        self.register_mem("spiflash", self.mem_map["spiflash"],
-            self.spiflash.bus, size=platform.spiflash_total_size)
+        self.add_constant("SPIFLASH_TOTAL_SIZE", platform.spiflash_total_size)
+        self.add_wb_slave(
+            self.mem_map["spiflash"],
+            self.spiflash.bus,
+            platform.spiflash_total_size)
+        self.add_memory_region(
+            "spiflash",
+            self.mem_map["spiflash"],
+            platform.spiflash_total_size)
 
         bios_size = 0x8000
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
         self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
 
-        #self.submodules.cas = cas.ControlAndStatus(platform, clk_freq)
-
-        # sdram
-        sdram_module = P3R1GE4JGF(self.clk_freq, "1:2")
-        self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
-            platform.request("ddram"),
-            sdram_module.memtype,
-            rd_bitslip=0,
-            wr_bitslip=4,
-            dqs_ddr_alignment="C0")
-        controller_settings = ControllerSettings(with_bandwidth=True)
-        self.register_sdram(self.ddrphy,
-                            sdram_module.geom_settings,
-                            sdram_module.timing_settings,
-                            controller_settings=controller_settings)
-        self.comb += [
-            self.ddrphy.clk4x_wr_strb.eq(self.crg.clk4x_wr_strb),
-            self.ddrphy.clk4x_rd_strb.eq(self.crg.clk4x_rd_strb),
-        ]
+        # Support for soft-emulation for full Linux support ----------------------------------------
+        if self.cpu_type == "vexriscv" and self.cpu_variant == "linux":
+            size = 0x4000
+            self.submodules.emulator_ram = wishbone.SRAM(size)
+            self.register_mem("emulator_ram", self.mem_map["emulator_ram"], self.emulator_ram.bus, size)
 
 
 SoC = BaseSoC

--- a/targets/atlys/crg.py
+++ b/targets/atlys/crg.py
@@ -1,0 +1,163 @@
+# Support for the Digilent Atlys board - digilentinc.com/atlys/
+
+from fractions import Fraction
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+
+class _CRG(Module):
+    def __init__(self, platform, clk_freq):
+        # Clock domains for the system (soft CPU and related components run at).
+        self.clock_domains.cd_sys = ClockDomain()
+        # Clock domains for the DDR interface.
+        self.clock_domains.cd_sdram_half = ClockDomain()
+        self.clock_domains.cd_sdram_full_wr = ClockDomain()
+        self.clock_domains.cd_sdram_full_rd = ClockDomain()
+        # Clock domain for peripherals (such as HDMI output).
+        self.clock_domains.cd_base50 = ClockDomain()
+        self.clock_domains.cd_encoder = ClockDomain()
+
+        self.reset = Signal()
+
+        # Input 100MHz clock
+        f0 = 100*1000000
+        clk100 = platform.request("clk100")
+        clk100a = Signal()
+        # Input 100MHz clock (buffered)
+        self.specials += Instance("IBUFG", i_I=clk100, o_O=clk100a)
+        clk100b = Signal()
+        self.specials += Instance(
+            "BUFIO2", p_DIVIDE=1,
+            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
+            i_I=clk100a, o_DIVCLK=clk100b)
+
+        f = Fraction(int(clk_freq), int(f0))
+        n, m = f.denominator, f.numerator
+        assert f0/n*m == clk_freq
+        p = 8
+
+        # Unbuffered output signals from the PLL. They need to be buffered
+        # before feeding into the fabric.
+        unbuf_sdram_full = Signal()
+        unbuf_sdram_half_a = Signal()
+        unbuf_sdram_half_b = Signal()
+        unbuf_encoder = Signal()
+        unbuf_sys = Signal()
+        unbuf_unused = Signal()
+
+        # PLL signals
+        pll_lckd = Signal()
+        pll_fb = Signal()
+        self.specials.pll = Instance(
+            "PLL_ADV",
+            name="crg_pll_adv",
+            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
+            p_REF_JITTER=.01,
+            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
+            p_DIVCLK_DIVIDE=1,
+            # Input Clocks (100MHz)
+            i_CLKIN1=clk100b,
+            p_CLKIN1_PERIOD=1e9/f0,
+            i_CLKIN2=0,
+            p_CLKIN2_PERIOD=0.,
+            i_CLKINSEL=1,
+            # Feedback
+            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
+            p_CLK_FEEDBACK="CLKFBOUT",
+            p_CLKFBOUT_MULT=m*p//n, p_CLKFBOUT_PHASE=0.,
+            # (300MHz) sdram wr rd
+            o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
+            p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//4,
+            # ( 66MHz) encoder
+            o_CLKOUT1=unbuf_encoder, p_CLKOUT1_DUTY_CYCLE=.5,
+            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=9,
+            # (150MHz) sdram_half - sdram dqs adr ctrl
+            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
+            p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=p//2,
+            # (150MHz) off-chip ddr
+            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
+            p_CLKOUT3_PHASE=250., p_CLKOUT3_DIVIDE=p//2,
+            # ( 50MHz) unused? - Was peripheral
+            o_CLKOUT4=unbuf_unused, p_CLKOUT4_DUTY_CYCLE=.5,
+            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=12,
+            # ( 75MHz) sysclk
+            o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
+            p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=p//1,
+        )
+
+
+        # power on reset?
+        reset = ~platform.request("cpu_reset") | self.reset
+        self.clock_domains.cd_por = ClockDomain()
+        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
+        self.sync.por += If(por != 0, por.eq(por - 1))
+        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
+
+        # System clock - 75MHz
+        self.specials += Instance("BUFG", name="sys_bufg", i_I=unbuf_sys, o_O=self.cd_sys.clk)
+        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
+
+
+        # SDRAM clocks
+        # ------------------------------------------------------------------------------
+        self.clk4x_wr_strb = Signal()
+        self.clk4x_rd_strb = Signal()
+
+        # sdram_full
+        self.specials += Instance("BUFPLL", name="sdram_full_bufpll",
+                                  p_DIVIDE=4,
+                                  i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys.clk,
+                                  i_LOCKED=pll_lckd,
+                                  o_IOCLK=self.cd_sdram_full_wr.clk,
+                                  o_SERDESSTROBE=self.clk4x_wr_strb)
+        self.comb += [
+            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
+            self.clk4x_rd_strb.eq(self.clk4x_wr_strb),
+        ]
+        # sdram_half
+        self.specials += Instance("BUFG", name="sdram_half_a_bufpll", i_I=unbuf_sdram_half_a, o_O=self.cd_sdram_half.clk)
+        clk_sdram_half_shifted = Signal()
+        self.specials += Instance("BUFG", name="sdram_half_b_bufpll", i_I=unbuf_sdram_half_b, o_O=clk_sdram_half_shifted)
+
+        output_clk = Signal()
+        clk = platform.request("ddram_clock")
+        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
+                                  p_INIT=0, p_SRTYPE="SYNC",
+                                  i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
+                                  i_C0=clk_sdram_half_shifted,
+                                  i_C1=~clk_sdram_half_shifted,
+                                  o_Q=output_clk)
+        self.specials += Instance("OBUFDS", i_I=output_clk, o_O=clk.p, o_OB=clk.n)
+
+        # Peripheral clock - 50MHz
+        # ------------------------------------------------------------------------------
+        # The peripheral clock is kept separate from the system clock to allow
+        # the system clock to be increased in the future.
+        dcm_base50_locked = Signal()
+        self.specials += [
+            Instance("DCM_CLKGEN", name="crg_periph_dcm_clkgen",
+                     p_CLKIN_PERIOD=10.0,
+                     p_CLKFX_MULTIPLY=2,
+                     p_CLKFX_DIVIDE=4,
+                     p_CLKFX_MD_MAX=0.5, # CLKFX_MULTIPLY/CLKFX_DIVIDE
+                     p_CLKFXDV_DIVIDE=2,
+                     p_SPREAD_SPECTRUM="NONE",
+                     p_STARTUP_WAIT="FALSE",
+
+                     i_CLKIN=clk100a,
+                     o_CLKFX=self.cd_base50.clk,
+                     o_LOCKED=dcm_base50_locked,
+                     i_FREEZEDCM=0,
+                     i_RST=ResetSignal(),
+                     ),
+            AsyncResetSynchronizer(self.cd_base50,
+                self.cd_sys.rst | ~dcm_base50_locked)
+        ]
+        platform.add_period_constraint(self.cd_base50.clk, 20)
+
+        # Encoder clock - 66 MHz
+        # ------------------------------------------------------------------------------
+        self.specials += Instance("BUFG", name="encoder_bufg", i_I=unbuf_encoder, o_O=self.cd_encoder.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_encoder, self.cd_sys.rst)

--- a/targets/atlys/hdmi2usb.py
+++ b/targets/atlys/hdmi2usb.py
@@ -10,15 +10,10 @@ from targets.atlys.video import SoC as BaseSoC
 
 
 class HDMI2USBSoC(BaseSoC):
-    csr_peripherals = (
-        "encoder_reader",
-        "encoder",
+    mem_map = dict(
+        **BaseSoC.mem_map,
+        encoder = 0x50000000,
     )
-    csr_map_update(BaseSoC.csr_map, csr_peripherals)
-    mem_map = {
-        "encoder": 0x50000000,  # (shadow @0xd0000000)
-    }
-    mem_map.update(BaseSoC.mem_map)
 
     def __init__(self, platform, *args, **kwargs):
         BaseSoC.__init__(self, platform, *args, **kwargs)
@@ -29,6 +24,7 @@ class HDMI2USBSoC(BaseSoC):
             reverse=True,
         )
         self.submodules.encoder_reader = EncoderDMAReader(encoder_port)
+        self.add_csr("encoder_reader")
         encoder_cdc = stream.AsyncFIFO([("data", 128)], 4)
         encoder_cdc = ClockDomainsRenamer({"write": "sys",
                                            "read": "encoder"})(encoder_cdc)
@@ -36,6 +32,7 @@ class HDMI2USBSoC(BaseSoC):
         encoder = Encoder(platform)
         encoder_streamer = USBStreamer(platform, platform.request("fx2"))
         self.submodules += encoder_cdc, encoder_buffer, encoder, encoder_streamer
+        self.add_csr("encoder")
 
         self.comb += [
             self.encoder_reader.source.connect(encoder_cdc.sink),

--- a/targets/atlys/hdmi2usb.py
+++ b/targets/atlys/hdmi2usb.py
@@ -5,7 +5,6 @@ from litex.soc.interconnect import stream
 from gateware.encoder import EncoderDMAReader, EncoderBuffer, Encoder
 from gateware.streamer import USBStreamer
 
-from targets.utils import csr_map_update
 from targets.atlys.video import SoC as BaseSoC
 
 

--- a/targets/atlys/net.py
+++ b/targets/atlys/net.py
@@ -21,8 +21,9 @@ class NetSoC(BaseSoC):
         # Ethernet ---------------------------------------------------------------------------------
         # Ethernet PHY
         self.submodules.ethphy = LiteEthPHY(
-            platform.request("eth_clocks"),
-            platform.request("eth"))
+            clock_pads = platform.request("eth_clocks"),
+            pads       = platform.request("eth"),
+            clk_freq   = clk_freq)
         self.add_csr("ethphy")
 
         # Ethernet MAC

--- a/targets/atlys/net.py
+++ b/targets/atlys/net.py
@@ -23,7 +23,7 @@ class NetSoC(BaseSoC):
         self.submodules.ethphy = LiteEthPHY(
             clock_pads = platform.request("eth_clocks"),
             pads       = platform.request("eth"),
-            clk_freq   = clk_freq)
+            clk_freq   = self.clk_freq)
         self.add_csr("ethphy")
 
         # Ethernet MAC

--- a/targets/basys3/base.py
+++ b/targets/basys3/base.py
@@ -1,101 +1,82 @@
 # Support for the Digilent Arty Board
 from migen import *
-from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex.soc.integration.soc_core import *
-from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
 
-from litedram.modules import MT41K128M16
-from litedram.phy import a7ddrphy
-from litedram.core import ControllerSettings
-
+from gateware import cas
 from gateware import info
-from gateware import led
 from gateware import spi_flash
 
-from targets.utils import csr_map_update, period_ns
+from targets.utils import period_ns
 
-
-class _CRG(Module):
-    def __init__(self, platform):
-        self.clock_domains.cd_sys = ClockDomain()
-        self.clock_domains.cd_sys4x = ClockDomain(reset_less=True)
-        self.clock_domains.cd_sys4x_dqs = ClockDomain(reset_less=True)
-        self.clock_domains.cd_clk200 = ClockDomain()
-        self.clock_domains.cd_clk50 = ClockDomain()
-
-        clk100 = platform.request("clk100")
-        rst = platform.request("user_btn")
-
-        pll_locked = Signal()
-        pll_fb = Signal()
-        self.pll_sys = Signal()
-        self.specials += [
-            Instance("PLLE2_BASE",
-                     p_STARTUP_WAIT="FALSE", o_LOCKED=pll_locked,
-
-                     # VCO @ 1600 MHz
-                     p_REF_JITTER1=0.01, p_CLKIN1_PERIOD=10.0,
-                     p_CLKFBOUT_MULT=16, p_DIVCLK_DIVIDE=1,
-                     i_CLKIN1=clk100, i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb,
-
-                     # 100 MHz
-                     p_CLKOUT0_DIVIDE=16, p_CLKOUT0_PHASE=0.0,
-                     o_CLKOUT0=self.pll_sys,
-            ),
-            Instance("BUFG", i_I=self.pll_sys, o_O=self.cd_sys.clk),
-            AsyncResetSynchronizer(self.cd_sys, ~pll_locked | rst),
-        ]
+from .crg import _CRG
 
 
 class BaseSoC(SoCCore):
-    csr_peripherals = (
-        "spiflash",
-        "info",
-    )
-    csr_map_update(SoCCore.csr_map, csr_peripherals)
-
-    mem_map = {
-        "spiflash": 0x20000000,  # (default shadow @0xa0000000)
-    }
-    mem_map.update(SoCCore.mem_map)
+    mem_map = {**SoCCore.mem_map, **{
+        'spiflash': 0x20000000,
+    }}
 
     def __init__(self, platform, spiflash="spiflash_1x", **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0x8000
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x8000
+        kwargs['integrated_rom_size']=0x8000
+        kwargs['integrated_sram_size']=0x8000
 
-        clk_freq = int(100e6)
-        SoCCore.__init__(self, platform, clk_freq, **kwargs)
+        sys_clk_freq = int(100e6)
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, clk_freq=sys_clk_freq, **kwargs)
 
-        self.submodules.crg = _CRG(platform)
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
         self.crg.cd_sys.clk.attr.add("keep")
-        self.platform.add_period_constraint(self.crg.cd_sys.clk, period_ns(clk_freq))
+        self.platform.add_period_constraint(self.crg.cd_sys.clk, period_ns(sys_clk_freq))
 
-        # Basic peripherals
+        # Basic peripherals ------------------------------------------------------------------------
         self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.add_csr("info")
+        self.submodules.cas = cas.ControlAndStatus(platform, sys_clk_freq)
+        self.add_csr("cas")
 
-        # spi flash
+        # Add debug interface if the CPU has one ---------------------------------------------------
+        if hasattr(self.cpu, "debug_bus"):
+            self.register_mem(
+                name="vexriscv_debug",
+                address=0xf00f0000,
+                interface=self.cpu.debug_bus,
+                size=0x100)
+
+        # Memory mapped SPI Flash ------------------------------------------------------------------
         spiflash_pads = platform.request(spiflash)
         spiflash_pads.clk = Signal()
-        self.specials += Instance("STARTUPE2",
-                                  i_CLK=0, i_GSR=0, i_GTS=0, i_KEYCLEARB=0, i_PACK=0,
-                                  i_USRCCLKO=spiflash_pads.clk, i_USRCCLKTS=0, i_USRDONEO=1, i_USRDONETS=1)
+        self.specials += Instance(
+            "STARTUPE2",
+            i_CLK=0, i_GSR=0, i_GTS=0, i_KEYCLEARB=0, i_PACK=0,
+            i_USRCCLKO=spiflash_pads.clk, i_USRCCLKTS=0, i_USRDONEO=1, i_USRDONETS=1)
         spiflash_dummy = {
             "spiflash_1x": 9,
             "spiflash_4x": 11,
         }
         self.submodules.spiflash = spi_flash.SpiFlash(
-                spiflash_pads,
-                dummy=spiflash_dummy[spiflash],
-                div=2)
-        self.add_constant("SPIFLASH_PAGE_SIZE", 256)
-        self.add_constant("SPIFLASH_SECTOR_SIZE", 0x10000)
-        self.add_wb_slave(mem_decoder(self.mem_map["spiflash"]), self.spiflash.bus)
+            spiflash_pads,
+            dummy=spiflash_dummy[spiflash],
+            div=2,
+            endianness=self.cpu.endianness)
+        self.add_csr("spiflash")
+        self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
+        self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
+        self.add_constant("SPIFLASH_TOTAL_SIZE", platform.spiflash_total_size)
+        self.add_wb_slave(
+            self.mem_map["spiflash"],
+            self.spiflash.bus,
+            platform.spiflash_total_size)
         self.add_memory_region(
-            "spiflash", self.mem_map["spiflash"], 16*1024*1024)
+            "spiflash",
+            self.mem_map["spiflash"],
+            platform.spiflash_total_size)
+
+        bios_size = 0x8000
+        self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
 
 
 SoC = BaseSoC

--- a/targets/basys3/crg.py
+++ b/targets/basys3/crg.py
@@ -1,0 +1,36 @@
+# Support for the Digilent Arty Board
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq):
+        self.clock_domains.cd_sys = ClockDomain()
+        self.clock_domains.cd_sys4x = ClockDomain(reset_less=True)
+        self.clock_domains.cd_sys4x_dqs = ClockDomain(reset_less=True)
+        self.clock_domains.cd_clk200 = ClockDomain()
+        self.clock_domains.cd_clk50 = ClockDomain()
+
+        clk100 = platform.request("clk100")
+        rst = platform.request("user_btn")
+
+        pll_locked = Signal()
+        pll_fb = Signal()
+        self.pll_sys = Signal()
+        self.specials += [
+            Instance("PLLE2_BASE",
+                     p_STARTUP_WAIT="FALSE", o_LOCKED=pll_locked,
+
+                     # VCO @ 1600 MHz
+                     p_REF_JITTER1=0.01, p_CLKIN1_PERIOD=10.0,
+                     p_CLKFBOUT_MULT=16, p_DIVCLK_DIVIDE=1,
+                     i_CLKIN1=clk100, i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb,
+
+                     # 100 MHz
+                     p_CLKOUT0_DIVIDE=16, p_CLKOUT0_PHASE=0.0,
+                     o_CLKOUT0=self.pll_sys,
+            ),
+            Instance("BUFG", i_I=self.pll_sys, o_O=self.cd_sys.clk),
+            AsyncResetSynchronizer(self.cd_sys, ~pll_locked | rst),
+        ]

--- a/targets/cmod_a7/base.py
+++ b/targets/cmod_a7/base.py
@@ -1,76 +1,82 @@
 # Support for the Digilent Cmod A7 Board
 from migen import *
-from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex.soc.integration.soc_core import *
 from litex.soc.integration.builder import *
 
+from gateware import cas
 from gateware import info
-from gateware import led
 from gateware import spi_flash
 
-from targets.utils import csr_map_update, period_ns
+from targets.utils import period_ns
 
-
-class _CRG(Module):
-    def __init__(self, platform):
-        self.clock_domains.cd_sys = ClockDomain()
-        self.clock_domains.cd_clk200 = ClockDomain()
-        clk12 = platform.request("clk12")
-        rst = platform.request("user_btn", 0)
-        self.specials += [
-            Instance("BUFG", i_I=clk12, o_O=self.cd_sys.clk),
-            AsyncResetSynchronizer(self.cd_sys, rst),
-        ]
+from .crg import _CRG
 
 
 class BaseSoC(SoCCore):
-    csr_peripherals = (
-        "spiflash",
-        "info",
-    )
-    csr_map_update(SoCCore.csr_map, csr_peripherals)
-
-    mem_map = {
-        "spiflash": 0x20000000,  # (default shadow @0xa0000000)
-    }
-    mem_map.update(SoCCore.mem_map)
+    mem_map = {**SoCCore.mem_map, **{
+        'spiflash': 0x20000000,
+    }}
 
     def __init__(self, platform, spiflash="spiflash_1x", **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0x8000
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x8000
+        kwargs['integrated_rom_size']=0x8000
+        kwargs['integrated_sram_size']=0x8000
 
-        clk_freq = int(100e6)
-        SoCCore.__init__(self, platform, clk_freq, **kwargs)
+        sys_clk_freq = int(100e6)
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, clk_freq=sys_clk_freq, **kwargs)
 
-        self.submodules.crg = _CRG(platform)
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
         self.crg.cd_sys.clk.attr.add("keep")
-        self.platform.add_period_constraint(self.crg.cd_sys.clk, period_ns(clk_freq))
+        self.platform.add_period_constraint(self.crg.cd_sys.clk, period_ns(sys_clk_freq))
 
-        # Basic peripherals
+        # Basic peripherals ------------------------------------------------------------------------
         self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.add_csr("info")
+        self.submodules.cas = cas.ControlAndStatus(platform, sys_clk_freq)
+        self.add_csr("cas")
 
-        # spi flash
+        # Add debug interface if the CPU has one ---------------------------------------------------
+        if hasattr(self.cpu, "debug_bus"):
+            self.register_mem(
+                name="vexriscv_debug",
+                address=0xf00f0000,
+                interface=self.cpu.debug_bus,
+                size=0x100)
+
+        # Memory mapped SPI Flash ------------------------------------------------------------------
         spiflash_pads = platform.request(spiflash)
         spiflash_pads.clk = Signal()
-        self.specials += Instance("STARTUPE2",
-                                  i_CLK=0, i_GSR=0, i_GTS=0, i_KEYCLEARB=0, i_PACK=0,
-                                  i_USRCCLKO=spiflash_pads.clk, i_USRCCLKTS=0, i_USRDONEO=1, i_USRDONETS=1)
+        self.specials += Instance(
+            "STARTUPE2",
+            i_CLK=0, i_GSR=0, i_GTS=0, i_KEYCLEARB=0, i_PACK=0,
+            i_USRCCLKO=spiflash_pads.clk, i_USRCCLKTS=0, i_USRDONEO=1, i_USRDONETS=1)
         spiflash_dummy = {
             "spiflash_1x": 9,
             "spiflash_4x": 11,
         }
         self.submodules.spiflash = spi_flash.SpiFlash(
-                spiflash_pads,
-                dummy=spiflash_dummy[spiflash],
-                div=2)
-        self.add_constant("SPIFLASH_PAGE_SIZE", 256)
-        self.add_constant("SPIFLASH_SECTOR_SIZE", 0x10000)
-        self.add_wb_slave(mem_decoder(self.mem_map["spiflash"]), self.spiflash.bus)
+            spiflash_pads,
+            dummy=spiflash_dummy[spiflash],
+            div=2,
+            endianness=self.cpu.endianness)
+        self.add_csr("spiflash")
+        self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
+        self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
+        self.add_constant("SPIFLASH_TOTAL_SIZE", platform.spiflash_total_size)
+        self.add_wb_slave(
+            self.mem_map["spiflash"],
+            self.spiflash.bus,
+            platform.spiflash_total_size)
         self.add_memory_region(
-            "spiflash", self.mem_map["spiflash"], 16*1024*1024)
+            "spiflash",
+            self.mem_map["spiflash"],
+            platform.spiflash_total_size)
+
+        bios_size = 0x8000
+        self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
 
 
 SoC = BaseSoC

--- a/targets/cmod_a7/crg.py
+++ b/targets/cmod_a7/crg.py
@@ -1,0 +1,16 @@
+# Support for the Digilent Cmod A7 Board
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq):
+        self.clock_domains.cd_sys = ClockDomain()
+        self.clock_domains.cd_clk200 = ClockDomain()
+        clk12 = platform.request("clk12")
+        rst = platform.request("user_btn", 0)
+        self.specials += [
+            Instance("BUFG", i_I=clk12, o_O=self.cd_sys.clk),
+            AsyncResetSynchronizer(self.cd_sys, rst),
+        ]

--- a/targets/galatea/base.py
+++ b/targets/galatea/base.py
@@ -1,8 +1,5 @@
 # Support for Numato Galatea - https://numato.com/product/galatea-pci-express-spartan-6-fpga-development-board
-from fractions import Fraction
-
 from migen import *
-from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
@@ -11,217 +8,56 @@ from litedram.modules import MT41J128M16
 from litedram.phy import s6ddrphy
 from litedram.core import ControllerSettings
 
+from gateware import cas
 from gateware import info
+from gateware import spi_flash
 
-from targets.utils import csr_map_update
-
-
-class _CRG(Module):
-    def __init__(self, platform, clk_freq):
-        # Clock domains for the system (soft CPU and related components run at).
-        self.clock_domains.cd_sys = ClockDomain()
-        self.clock_domains.cd_sys2x = ClockDomain()
-        # Clock domains for the DDR interface.
-        self.clock_domains.cd_sdram_half = ClockDomain()
-        self.clock_domains.cd_sdram_full_wr = ClockDomain()
-        self.clock_domains.cd_sdram_full_rd = ClockDomain()
-        # Clock domain for peripherals (such as HDMI output).
-        self.clock_domains.cd_base50 = ClockDomain()
-
-        self.reset = Signal()
-
-        # Input 100MHz clock
-        f0 = 100*1000000
-        clk100 = platform.request("clk100")
-        clk100a = Signal()
-        # Input 100MHz clock (buffered)
-        self.specials += Instance("IBUFG", i_I=clk100, o_O=clk100a)
-        clk100b = Signal()
-        self.specials += Instance(
-            "BUFIO2", p_DIVIDE=1,
-            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
-            i_I=clk100a, o_DIVCLK=clk100b)
-
-        f = Fraction(int(clk_freq), int(f0))
-        n, m = f.denominator, f.numerator
-        assert f0/n*m == clk_freq
-        p = 8
-
-        # Unbuffered output signals from the PLL. They need to be buffered
-        # before feeding into the fabric.
-        unbuf_sdram_full = Signal()
-        unbuf_sdram_half_a = Signal()
-        unbuf_sdram_half_b = Signal()
-        unbuf_encoder = Signal()
-        unbuf_sys = Signal()
-        unbuf_sys2x = Signal()
-
-        # PLL signals
-        pll_lckd = Signal()
-        pll_fb = Signal()
-        self.specials.pll = Instance(
-            "PLL_ADV",
-            name="crg_pll_adv",
-            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
-            p_REF_JITTER=.01,
-            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
-            p_DIVCLK_DIVIDE=1,
-            # Input Clocks (100MHz)
-            i_CLKIN1=clk100b,
-            p_CLKIN1_PERIOD=1e9/f0,
-            i_CLKIN2=0,
-            p_CLKIN2_PERIOD=0.,
-            i_CLKINSEL=1,
-            # Feedback
-            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
-            p_CLK_FEEDBACK="CLKFBOUT",
-            p_CLKFBOUT_MULT=m*p//n, p_CLKFBOUT_PHASE=0.,
-            # (400MHz) ddr3 wr/rd full clock
-            o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
-            p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//8,
-            # ( 66MHz) encoder
-            o_CLKOUT1=unbuf_encoder, p_CLKOUT1_DUTY_CYCLE=.5,
-            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=6,
-            # (200MHz) sdram_half - ddr3 dqs adr ctrl off-chip
-            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
-            p_CLKOUT2_PHASE=230., p_CLKOUT2_DIVIDE=p//4,
-            # (200MHz) off-chip ddr - ddr3 half clock
-            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
-            p_CLKOUT3_PHASE=210., p_CLKOUT3_DIVIDE=p//4,
-            # (100MHz) sys2x - 2x system clock
-            o_CLKOUT4=unbuf_sys2x, p_CLKOUT4_DUTY_CYCLE=.5,
-            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=p//2,
-            # ( 50MHz) periph / sys - system clock
-            o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
-            p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=p//1,
-        )
-
-
-        # power on reset?
-        reset = ~platform.request("cpu_reset") | self.reset
-        self.clock_domains.cd_por = ClockDomain()
-        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
-        self.sync.por += If(por != 0, por.eq(por - 1))
-        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
-
-        # System clock - 50MHz
-        self.specials += Instance("BUFG", name="sys_bufg", i_I=unbuf_sys, o_O=self.cd_sys.clk)
-        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
-        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
-
-        # sys2x
-        self.specials += Instance("BUFG", name="sys2x_bufg", i_I=unbuf_sys2x, o_O=self.cd_sys2x.clk)
-        self.specials += AsyncResetSynchronizer(self.cd_sys2x, ~pll_lckd | (por > 0))
-
-        # SDRAM clocks
-        # ------------------------------------------------------------------------------
-        self.clk8x_wr_strb = Signal()
-        self.clk8x_rd_strb = Signal()
-
-        # sdram_full
-        self.specials += Instance("BUFPLL", name="sdram_full_bufpll",
-                                  p_DIVIDE=4,
-                                  i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys2x.clk,
-                                  i_LOCKED=pll_lckd,
-                                  o_IOCLK=self.cd_sdram_full_wr.clk,
-                                  o_SERDESSTROBE=self.clk8x_wr_strb)
-        self.comb += [
-            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
-            self.clk8x_rd_strb.eq(self.clk8x_wr_strb),
-        ]
-        # sdram_half
-        self.specials += Instance("BUFG", name="sdram_half_a_bufpll", i_I=unbuf_sdram_half_a, o_O=self.cd_sdram_half.clk)
-        clk_sdram_half_shifted = Signal()
-        self.specials += Instance("BUFG", name="sdram_half_b_bufpll", i_I=unbuf_sdram_half_b, o_O=clk_sdram_half_shifted)
-
-        output_clk = Signal()
-        clk = platform.request("ddram_clock")
-        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
-                                  p_INIT=0, p_SRTYPE="SYNC",
-                                  i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
-                                  i_C0=clk_sdram_half_shifted,
-                                  i_C1=~clk_sdram_half_shifted,
-                                  o_Q=output_clk)
-        self.specials += Instance("OBUFDS", i_I=output_clk, o_O=clk.p, o_OB=clk.n)
-
-        # Peripheral clock - 50MHz
-        # ------------------------------------------------------------------------------
-        # The peripheral clock is kept separate from the system clock to allow
-        # the system clock to be increased in the future.
-        dcm_base50_locked = Signal()
-        self.specials += [
-            Instance("DCM_CLKGEN", name="crg_periph_dcm_clkgen",
-                     p_CLKIN_PERIOD=10.0,
-                     p_CLKFX_MULTIPLY=2,
-                     p_CLKFX_DIVIDE=4,
-                     p_CLKFX_MD_MAX=0.5, # CLKFX_MULTIPLY/CLKFX_DIVIDE
-                     p_CLKFXDV_DIVIDE=2,
-                     p_SPREAD_SPECTRUM="NONE",
-                     p_STARTUP_WAIT="FALSE",
-
-                     i_CLKIN=clk100a,
-                     o_CLKFX=self.cd_base50.clk,
-                     o_LOCKED=dcm_base50_locked,
-                     i_FREEZEDCM=0,
-                     i_RST=ResetSignal(),
-                     ),
-            AsyncResetSynchronizer(self.cd_base50,
-                self.cd_sys.rst | ~dcm_base50_locked)
-        ]
-        platform.add_period_constraint(self.cd_base50.clk, 20)
+from .crg import _CRG
 
 
 class BaseSoC(SoCSDRAM):
-    csr_peripherals = (
-        "spiflash",
-        "ddrphy",
-        "info",
-    )
-    csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
+    mem_map = {**SoCSDRAM.mem_map, **{
+        spiflash=0x20000000,
+    }}
 
-    # FIXME: Add spiflash
-    #mem_map = {
-    #    "spiflash": 0x20000000,  # (default shadow @0xa0000000)
-    #}
-    #mem_map.update(SoCSDRAM.mem_map)
+    def __init__(self, platform, spiflash="spiflash_1x", **kwargs):
+        kwargs['integrated_rom_size']=0x8000
+        kwargs['integrated_sram_size']=0x8000
 
-    def __init__(self, platform, **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0x8000
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x4000
+        sys_clk_freq = 50*1000000
+        # SoCSDRAM ---------------------------------------------------------------------------------
+        SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq, **kwargs)
 
-        if 'expansion' in kwargs:
-            tofe_board_name = kwargs.get('expansion')
-            del kwargs['expansion']
-        else:
-            tofe_board_name = None
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/sys_clk_freq)
 
+        # DDR3 SDRAM -------------------------------------------------------------------------------
+        if True:
+            sdram_module = MT41J128M16(self.clk_freq, "1:4")
+            self.submodules.ddrphy = s6ddrphy.S6QuarterRateDDRPHY(
+                platform.request("ddram"),
+                rd_bitslip=0,
+                wr_bitslip=4,
+                dqs_ddr_alignment="C0")
+            controller_settings = ControllerSettings(with_bandwidth=True)
+            self.add_csr("ddrphy")
+            self.register_sdram(
+                self.ddrphy,
+                geom_settings   = sdram_module.geom_settings,
+                timing_settings = sdram_module.timing_settings,
+                controller_settings=controller_settings)
+            self.comb += [
+                self.ddrphy.clk8x_wr_strb.eq(self.crg.clk8x_wr_strb),
+                self.ddrphy.clk8x_rd_strb.eq(self.crg.clk8x_rd_strb),
+            ]
 
-        clk_freq = 50*1000000
-        SoCSDRAM.__init__(self, platform, clk_freq, **kwargs)
-
-        self.submodules.crg = _CRG(platform, clk_freq)
-        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/clk_freq)
-
-        # Basic peripherals
+        # Basic peripherals ------------------------------------------------------------------------
         self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.add_csr("info")
+        self.submodules.cas = cas.ControlAndStatus(platform, sys_clk_freq)
+        self.add_csr("cas")
 
-        # sdram
-        sdram_module = MT41J128M16(self.clk_freq, "1:4")
-        self.submodules.ddrphy = s6ddrphy.S6QuarterRateDDRPHY(
-            platform.request("ddram"),
-            rd_bitslip=0,
-            wr_bitslip=4,
-            dqs_ddr_alignment="C0")
-        controller_settings = ControllerSettings(with_bandwidth=True)
-        self.register_sdram(self.ddrphy,
-                            sdram_module.geom_settings,
-                            sdram_module.timing_settings,
-                            controller_settings=controller_settings)
-        self.comb += [
-            self.ddrphy.clk8x_wr_strb.eq(self.crg.clk8x_wr_strb),
-            self.ddrphy.clk8x_rd_strb.eq(self.crg.clk8x_rd_strb),
-        ]
+
 
 SoC = BaseSoC

--- a/targets/galatea/base.py
+++ b/targets/galatea/base.py
@@ -1,4 +1,5 @@
 # Support for Numato Galatea - https://numato.com/product/galatea-pci-express-spartan-6-fpga-development-board
+
 from migen import *
 
 from litex.soc.integration.soc_sdram import *

--- a/targets/galatea/base.py
+++ b/targets/galatea/base.py
@@ -17,7 +17,7 @@ from .crg import _CRG
 
 class BaseSoC(SoCSDRAM):
     mem_map = {**SoCSDRAM.mem_map, **{
-        spiflash=0x20000000,
+        'spiflash': 0x20000000,
     }}
 
     def __init__(self, platform, spiflash="spiflash_1x", **kwargs):

--- a/targets/galatea/crg.py
+++ b/targets/galatea/crg.py
@@ -1,0 +1,161 @@
+# Support for Numato Galatea - https://numato.com/product/galatea-pci-express-spartan-6-fpga-development-board
+
+from fractions import Fraction
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+
+class _CRG(Module):
+    def __init__(self, platform, clk_freq):
+        # Clock domains for the system (soft CPU and related components run at).
+        self.clock_domains.cd_sys = ClockDomain()
+        self.clock_domains.cd_sys2x = ClockDomain()
+        # Clock domains for the DDR interface.
+        self.clock_domains.cd_sdram_half = ClockDomain()
+        self.clock_domains.cd_sdram_full_wr = ClockDomain()
+        self.clock_domains.cd_sdram_full_rd = ClockDomain()
+        # Clock domain for peripherals (such as HDMI output).
+        self.clock_domains.cd_base50 = ClockDomain()
+
+        self.reset = Signal()
+
+        # Input 100MHz clock
+        f0 = 100*1000000
+        clk100 = platform.request("clk100")
+        clk100a = Signal()
+        # Input 100MHz clock (buffered)
+        self.specials += Instance("IBUFG", i_I=clk100, o_O=clk100a)
+        clk100b = Signal()
+        self.specials += Instance(
+            "BUFIO2", p_DIVIDE=1,
+            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
+            i_I=clk100a, o_DIVCLK=clk100b)
+
+        f = Fraction(int(clk_freq), int(f0))
+        n, m = f.denominator, f.numerator
+        assert f0/n*m == clk_freq
+        p = 8
+
+        # Unbuffered output signals from the PLL. They need to be buffered
+        # before feeding into the fabric.
+        unbuf_sdram_full = Signal()
+        unbuf_sdram_half_a = Signal()
+        unbuf_sdram_half_b = Signal()
+        unbuf_encoder = Signal()
+        unbuf_sys = Signal()
+        unbuf_sys2x = Signal()
+
+        # PLL signals
+        pll_lckd = Signal()
+        pll_fb = Signal()
+        self.specials.pll = Instance(
+            "PLL_ADV",
+            name="crg_pll_adv",
+            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
+            p_REF_JITTER=.01,
+            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
+            p_DIVCLK_DIVIDE=1,
+            # Input Clocks (100MHz)
+            i_CLKIN1=clk100b,
+            p_CLKIN1_PERIOD=1e9/f0,
+            i_CLKIN2=0,
+            p_CLKIN2_PERIOD=0.,
+            i_CLKINSEL=1,
+            # Feedback
+            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
+            p_CLK_FEEDBACK="CLKFBOUT",
+            p_CLKFBOUT_MULT=m*p//n, p_CLKFBOUT_PHASE=0.,
+            # (400MHz) ddr3 wr/rd full clock
+            o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
+            p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//8,
+            # ( 66MHz) encoder
+            o_CLKOUT1=unbuf_encoder, p_CLKOUT1_DUTY_CYCLE=.5,
+            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=6,
+            # (200MHz) sdram_half - ddr3 dqs adr ctrl off-chip
+            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
+            p_CLKOUT2_PHASE=230., p_CLKOUT2_DIVIDE=p//4,
+            # (200MHz) off-chip ddr - ddr3 half clock
+            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
+            p_CLKOUT3_PHASE=210., p_CLKOUT3_DIVIDE=p//4,
+            # (100MHz) sys2x - 2x system clock
+            o_CLKOUT4=unbuf_sys2x, p_CLKOUT4_DUTY_CYCLE=.5,
+            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=p//2,
+            # ( 50MHz) periph / sys - system clock
+            o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
+            p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=p//1,
+        )
+
+
+        # power on reset?
+        reset = ~platform.request("cpu_reset") | self.reset
+        self.clock_domains.cd_por = ClockDomain()
+        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
+        self.sync.por += If(por != 0, por.eq(por - 1))
+        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
+
+        # System clock - 50MHz
+        self.specials += Instance("BUFG", name="sys_bufg", i_I=unbuf_sys, o_O=self.cd_sys.clk)
+        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
+
+        # sys2x
+        self.specials += Instance("BUFG", name="sys2x_bufg", i_I=unbuf_sys2x, o_O=self.cd_sys2x.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_sys2x, ~pll_lckd | (por > 0))
+
+        # SDRAM clocks
+        # ------------------------------------------------------------------------------
+        self.clk8x_wr_strb = Signal()
+        self.clk8x_rd_strb = Signal()
+
+        # sdram_full
+        self.specials += Instance("BUFPLL", name="sdram_full_bufpll",
+                                  p_DIVIDE=4,
+                                  i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys2x.clk,
+                                  i_LOCKED=pll_lckd,
+                                  o_IOCLK=self.cd_sdram_full_wr.clk,
+                                  o_SERDESSTROBE=self.clk8x_wr_strb)
+        self.comb += [
+            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
+            self.clk8x_rd_strb.eq(self.clk8x_wr_strb),
+        ]
+        # sdram_half
+        self.specials += Instance("BUFG", name="sdram_half_a_bufpll", i_I=unbuf_sdram_half_a, o_O=self.cd_sdram_half.clk)
+        clk_sdram_half_shifted = Signal()
+        self.specials += Instance("BUFG", name="sdram_half_b_bufpll", i_I=unbuf_sdram_half_b, o_O=clk_sdram_half_shifted)
+
+        output_clk = Signal()
+        clk = platform.request("ddram_clock")
+        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
+                                  p_INIT=0, p_SRTYPE="SYNC",
+                                  i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
+                                  i_C0=clk_sdram_half_shifted,
+                                  i_C1=~clk_sdram_half_shifted,
+                                  o_Q=output_clk)
+        self.specials += Instance("OBUFDS", i_I=output_clk, o_O=clk.p, o_OB=clk.n)
+
+        # Peripheral clock - 50MHz
+        # ------------------------------------------------------------------------------
+        # The peripheral clock is kept separate from the system clock to allow
+        # the system clock to be increased in the future.
+        dcm_base50_locked = Signal()
+        self.specials += [
+            Instance("DCM_CLKGEN", name="crg_periph_dcm_clkgen",
+                     p_CLKIN_PERIOD=10.0,
+                     p_CLKFX_MULTIPLY=2,
+                     p_CLKFX_DIVIDE=4,
+                     p_CLKFX_MD_MAX=0.5, # CLKFX_MULTIPLY/CLKFX_DIVIDE
+                     p_CLKFXDV_DIVIDE=2,
+                     p_SPREAD_SPECTRUM="NONE",
+                     p_STARTUP_WAIT="FALSE",
+
+                     i_CLKIN=clk100a,
+                     o_CLKFX=self.cd_base50.clk,
+                     o_LOCKED=dcm_base50_locked,
+                     i_FREEZEDCM=0,
+                     i_RST=ResetSignal(),
+                     ),
+            AsyncResetSynchronizer(self.cd_base50,
+                self.cd_sys.rst | ~dcm_base50_locked)
+        ]
+        platform.add_period_constraint(self.cd_base50.clk, 20)

--- a/targets/ice40_hx8k_b_evn/base.py
+++ b/targets/ice40_hx8k_b_evn/base.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys
 import struct
 import os.path
@@ -15,7 +16,7 @@ from gateware import spi_flash
 
 from targets.utils import csr_map_update
 
-from litex.soc.cores.uart import UARTWishboneBridge 
+from litex.soc.cores.uart import UARTWishboneBridge
 
 class _CRG(Module):
     def __init__(self, platform):
@@ -44,19 +45,10 @@ class _CRG(Module):
 
 
 class BaseSoC(SoCCore):
-    csr_peripherals = (
-        "spiflash",
-        "cas",
-    )
-    csr_map_update(SoCCore.csr_map, csr_peripherals)
-
-    mem_map_overlay = {
+    mem_map = {**SoCSDRAM.mem_map, **{
         "spiflash": 0x20000000,  # (default shadow @0xa0000000)
         "sram": 0,
-    }
-    mem_map = dict(SoCCore.mem_map, **mem_map_overlay)
-    
-    #mem_map.update(SoCCore.mem_map)
+    }}
 
     def __init__(self, platform, **kwargs):
         if 'integrated_rom_size' not in kwargs:

--- a/targets/ice40_hx8k_b_evn/base.py
+++ b/targets/ice40_hx8k_b_evn/base.py
@@ -20,6 +20,7 @@ from litex.soc.cores.uart import UARTWishboneBridge
 class BaseSoC(SoCCore):
     mem_map = {**SoCCore.mem_map, **{
         'spiflash': 0x20000000,
+        'vexriscv_debug': 0xf00f0000,
         'sram': 0,
     }}
 
@@ -35,7 +36,7 @@ class BaseSoC(SoCCore):
         # SoCCore ----------------------------------------------------------------------------------
         SoCCore.__init__(self, platform, sys_clk_freq, **kwargs)
 
-        self.submodules.uart_bridge = UARTWishboneBridge(platform.request("serial_1"), sys_clk_freq, baudrate=115200)
+        self.submodules.uart_bridge = UARTWishboneBridge(platform.request("serial"), sys_clk_freq, baudrate=115200)
         self.add_wb_master(self.uart_bridge.wishbone)
         self.register_mem("vexriscv_debug", 0xf00f0000, self.cpu.debug_bus, 0x100)
 
@@ -78,12 +79,12 @@ class BaseSoC(SoCCore):
 
         # We don't have a DRAM, so use the remaining SPI flash for user
         # program.
-        self.add_memory_region("user_flash",
-            self.flash_boot_address,
-            # Leave a grace area- possible one-by-off bug in add_memory_region?
-            # Possible fix: addr < origin + length - 1
-            platform.spiflash_total_size - (self.flash_boot_address - self.mem_map["spiflash"]) - 0x100,
-            type="cached+linker")
+        #self.add_memory_region("user_flash",
+        #    self.flash_boot_address,
+        #    # Leave a grace area- possible one-by-off bug in add_memory_region?
+        #    # Possible fix: addr < origin + length - 1
+        #    platform.spiflash_total_size - (self.flash_boot_address - self.mem_map["spiflash"]) - 0x100,
+        #    type="cached+linker")
 
         # Disable final deep-sleep power down so firmware words are loaded
         # onto softcore's address bus.

--- a/targets/ice40_hx8k_b_evn/crg.py
+++ b/targets/ice40_hx8k_b_evn/crg.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python3
-import sys
-import struct
-import os.path
-import argparse
 
 from migen import *
 from migen.genlib.resetsync import AsyncResetSynchronizer

--- a/targets/ice40_up5k_b_evn/base.py
+++ b/targets/ice40_up5k_b_evn/base.py
@@ -61,10 +61,8 @@ class BaseSoC(SoCCore):
     }}
 
     def __init__(self, platform, **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0
+        kwargs['integrated_rom_size']=0
+        kwargs['integrated_sram_size']=0
 
         # FIXME: Force either lite or minimal variants of CPUs; full is too big.
         platform.add_extension(pmod_serial)

--- a/targets/ice40_up5k_b_evn/bridge.py
+++ b/targets/ice40_up5k_b_evn/bridge.py
@@ -4,23 +4,19 @@ from litex.soc.cores.uart import UARTWishboneBridge
 from litescope import LiteScopeAnalyzer
 from litescope import LiteScopeIO
 
-from targets.utils import csr_map_update
 from targets.ice40_up5k_b_evn.base import BaseSoC
 
 
 class BridgeSoC(BaseSoC):
-    csr_peripherals = (
-        "analyzer",
-        "io",
-    )
-    csr_map_update(BaseSoC.csr_map, csr_peripherals)
-
     def __init__(self, platform, *args, **kwargs):
         kwargs['cpu_type'] = None
         BaseSoC.__init__(self, platform, *args, with_uart=False, **kwargs)
 
         self.add_cpu_or_bridge(UARTWishboneBridge(platform.request("serial"), self.clk_freq, baudrate=115200))
         self.add_wb_master(self.cpu_or_bridge.wishbone)
+
+        self.add_csr("analyzer")
+        self.add_csr("io")
 
 
 SoC = BridgeSoC

--- a/targets/icebreaker/base.py
+++ b/targets/icebreaker/base.py
@@ -64,10 +64,8 @@ class BaseSoC(SoCCore):
     }}
 
     def __init__(self, platform, **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0
+        kwargs['integrated_rom_size']=0
+        kwargs['integrated_sram_size']=0
 
         # FIXME: Force either lite or minimal variants of CPUs; full is too big.
 

--- a/targets/icebreaker/base.py
+++ b/targets/icebreaker/base.py
@@ -59,16 +59,9 @@ class _CRG(Module):
 
 
 class BaseSoC(SoCCore):
-    csr_peripherals = (
-        "spiflash",
-        "cas",
-    )
-    csr_map_update(SoCCore.csr_map, csr_peripherals)
-
-    mem_map = {
+    mem_map = {**SoCCore, **{
         "spiflash": 0x20000000,  # (default shadow @0xa0000000)
-    }
-    mem_map.update(SoCCore.mem_map)
+    }}
 
     def __init__(self, platform, **kwargs):
         if 'integrated_rom_size' not in kwargs:
@@ -91,6 +84,7 @@ class BaseSoC(SoCCore):
 
         # Control and Status
         self.submodules.cas = cas.ControlAndStatus(platform, clk_freq)
+        self.add_csr("cas")
 
         # SPI flash peripheral
         # TODO: Inferred tristate not currently supported by nextpnr; upgrade
@@ -100,6 +94,7 @@ class BaseSoC(SoCCore):
             dummy=platform.spiflash_read_dummy_bits,
             div=platform.spiflash_clock_div,
             endianness=self.cpu.endianness)
+        self.add_csr("spiflash")
         self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
         self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
         self.register_mem("spiflash", self.mem_map["spiflash"],

--- a/targets/icefun/base.py
+++ b/targets/icefun/base.py
@@ -46,10 +46,8 @@ class BaseSoC(SoCCore):
     }}
 
     def __init__(self, platform, **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x2800
+        kwargs['integrated_rom_size']=0
+        kwargs['integrated_sram_size']=0x2800
 
         # FIXME: Force either lite or minimal variants of CPUs; full is too big.
 

--- a/targets/icefun/base.py
+++ b/targets/icefun/base.py
@@ -13,8 +13,6 @@ from litex.soc.integration.builder import *
 from gateware import cas
 from gateware import spi_flash
 
-from targets.utils import csr_map_update
-
 
 class _CRG(Module):
     def __init__(self, platform):
@@ -43,16 +41,9 @@ class _CRG(Module):
 
 
 class BaseSoC(SoCCore):
-    csr_peripherals = (
-        "spiflash",
-        "cas",
-    )
-    csr_map_update(SoCCore.csr_map, csr_peripherals)
-
-    mem_map = {
-        "spiflash": 0x20000000,  # (default shadow @0xa0000000)
-    }
-    mem_map.update(SoCCore.mem_map)
+    mem_map = {**SoCCore.mem_map, **{
+        "spiflash": 0x20000000,
+    }}
 
     def __init__(self, platform, **kwargs):
         if 'integrated_rom_size' not in kwargs:
@@ -72,12 +63,14 @@ class BaseSoC(SoCCore):
 
         # Control and Status
         self.submodules.cas = cas.ControlAndStatus(platform, clk_freq)
+        self.add_csr("cas")
 
         # SPI flash peripheral
         self.submodules.spiflash = spi_flash.SpiFlashSingle(
             platform.request("spiflash"),
             dummy=platform.spiflash_read_dummy_bits,
             div=platform.spiflash_clock_div)
+        self.add_csr("spiflash")
         self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
         self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
         self.register_mem("spiflash", self.mem_map["spiflash"],

--- a/targets/mimas_a7/base.py
+++ b/targets/mimas_a7/base.py
@@ -1,142 +1,108 @@
 # Support for Numato Mimas A7 board
 from migen import *
-from migen.genlib.resetsync import AsyncResetSynchronizer
 
-from litex.soc.integration.soc_core import mem_decoder
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
-from litex.soc.cores.uart import *
+from litex.soc.interconnect import wishbone
 
 from litedram.modules import MT41K128M16
-from litedram.phy import a7ddrphy
+from litedram.phy import s7ddrphy
 from litedram.core import ControllerSettings
 
+from gateware import cas
 from gateware import info
 from gateware import spi_flash
 
-from targets.utils import csr_map_update, period_ns
-
-
-class _CRG(Module):
-    def __init__(self, platform):
-        self.clock_domains.cd_sys = ClockDomain()
-        self.clock_domains.cd_sys4x = ClockDomain(reset_less=True)
-        self.clock_domains.cd_sys4x_dqs = ClockDomain(reset_less=True)
-        self.clock_domains.cd_clk200 = ClockDomain()
-        self.clock_domains.cd_clk100 = ClockDomain()
-
-        clk100 = platform.request("clk100")
-        rst = platform.request("cpu_reset")
-
-        pll_locked = Signal()
-        pll_fb = Signal()
-        self.pll_sys = Signal()
-        pll_sys4x = Signal()
-        pll_sys4x_dqs = Signal()
-        pll_clk200 = Signal()
-        self.specials += [
-            Instance("PLLE2_BASE",
-                     p_STARTUP_WAIT="FALSE", o_LOCKED=pll_locked,
-
-                     # VCO @ 1600 MHz
-                     p_REF_JITTER1=0.01, p_CLKIN1_PERIOD=10.0,
-                     p_CLKFBOUT_MULT=16, p_DIVCLK_DIVIDE=1,
-                     i_CLKIN1=clk100, i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb,
-
-                     # 100 MHz
-                     p_CLKOUT0_DIVIDE=16, p_CLKOUT0_PHASE=0.0,
-                     o_CLKOUT0=self.pll_sys,
-
-                     # 400 MHz
-                     p_CLKOUT1_DIVIDE=4, p_CLKOUT1_PHASE=0.0,
-                     o_CLKOUT1=pll_sys4x,
-
-                     # 400 MHz dqs
-                     p_CLKOUT2_DIVIDE=4, p_CLKOUT2_PHASE=90.0,
-                     o_CLKOUT2=pll_sys4x_dqs,
-
-                     # 200 MHz
-                     p_CLKOUT3_DIVIDE=8, p_CLKOUT3_PHASE=0.0,
-                     o_CLKOUT3=pll_clk200
-            ),
-            Instance("BUFG", i_I=self.pll_sys, o_O=self.cd_sys.clk),
-            Instance("BUFG", i_I=pll_sys4x, o_O=self.cd_sys4x.clk),
-            Instance("BUFG", i_I=pll_sys4x_dqs, o_O=self.cd_sys4x_dqs.clk),
-            Instance("BUFG", i_I=pll_clk200, o_O=self.cd_clk200.clk),
-            Instance("BUFG", i_I=clk100, o_O=self.cd_clk100.clk),
-            AsyncResetSynchronizer(self.cd_sys, ~pll_locked | rst),
-            AsyncResetSynchronizer(self.cd_clk200, ~pll_locked | rst),
-            AsyncResetSynchronizer(self.cd_clk100, ~pll_locked | rst),
-        ]
-
-        reset_counter = Signal(4, reset=15)
-        ic_reset = Signal(reset=1)
-        self.sync.clk200 += \
-            If(reset_counter != 0,
-                reset_counter.eq(reset_counter - 1)
-            ).Else(
-                ic_reset.eq(0)
-            )
-        self.specials += Instance("IDELAYCTRL", i_REFCLK=ClockSignal("clk200"), i_RST=ic_reset)
+from .crg import _CRG
 
 
 class BaseSoC(SoCSDRAM):
-    csr_peripherals = (
-        "spiflash",
-        "ddrphy",
-        "info",
-    )
-    csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
-
-    mem_map = {
-        "spiflash": 0x20000000,  # (default shadow @0xa0000000)
-    }
-    mem_map.update(SoCSDRAM.mem_map)
+    mem_map = {**SoCSDRAM.mem_map, **{
+        'spiflash': 0x20000000,
+    }}
 
     def __init__(self, platform, spiflash="spiflash_1x", **kwargs):
-        clk_freq = int(100e6)
-        SoCSDRAM.__init__(self, platform, clk_freq,
-            integrated_rom_size=0x10000,
-            integrated_sram_size=0x10000,
-            **kwargs)
+        kwargs['integrated_rom_size']=0x10000
+        kwargs['integrated_sram_size']=0x10000
 
-        self.submodules.crg = _CRG(platform)
-        self.crg.cd_sys.clk.attr.add("keep")
-        self.platform.add_period_constraint(self.crg.cd_sys.clk, period_ns(clk_freq))
+        sys_clk_freq = int(100e6)
+        # SoCSDRAM ---------------------------------------------------------------------------------
+        SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq, **kwargs)
 
-        # Basic peripherals
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/sys_clk_freq)
+
+        # DDR3 SDRAM -------------------------------------------------------------------------------
+        if True:
+            sdram_module = MT41K128M16(sys_clk_freq, "1:4")
+            self.submodules.ddrphy = s7ddrphy.A7DDRPHY(
+                platform.request("ddram"),
+                memtype      = sdram_module.memtype,
+                nphases      = 4,
+                sys_clk_freq = sys_clk_freq)
+            self.add_csr("ddrphy")
+            self.register_sdram(
+                self.ddrphy,
+                geom_settings   = sdram_module.geom_settings,
+                timing_settings = sdram_module.timing_settings,
+                controller_settings=ControllerSettings(
+                    with_bandwidth=True,
+                    cmd_buffer_depth=8,
+                    with_refresh=True))
+
+        # Basic peripherals ------------------------------------------------------------------------
         self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.add_csr("info")
+        self.submodules.cas = cas.ControlAndStatus(platform, sys_clk_freq)
+        self.add_csr("cas")
 
-        # sdram
-        self.submodules.ddrphy = a7ddrphy.A7DDRPHY(platform.request("ddram"))
-        sdram_module = MT41K128M16(self.clk_freq, "1:4")
-        self.register_sdram(self.ddrphy,
-                            sdram_module.geom_settings,
-                            sdram_module.timing_settings,
-                            controller_settings=ControllerSettings(
-                                with_bandwidth=True,
-                                cmd_buffer_depth=8,
-                                with_refresh=True))
+        # Add debug interface if the CPU has one ---------------------------------------------------
+        if hasattr(self.cpu, "debug_bus"):
+            self.register_mem(
+                name="vexriscv_debug",
+                address=0xf00f0000,
+                interface=self.cpu.debug_bus,
+                size=0x100)
 
-        # spi flash
+        # Memory mapped SPI Flash ------------------------------------------------------------------
         spiflash_pads = platform.request(spiflash)
         spiflash_pads.clk = Signal()
-        self.specials += Instance("STARTUPE2",
-                                  i_CLK=0, i_GSR=0, i_GTS=0, i_KEYCLEARB=0, i_PACK=0,
-                                  i_USRCCLKO=spiflash_pads.clk, i_USRCCLKTS=0, i_USRDONEO=1, i_USRDONETS=1)
+        self.specials += Instance(
+            "STARTUPE2",
+            i_CLK=0, i_GSR=0, i_GTS=0, i_KEYCLEARB=0, i_PACK=0,
+            i_USRCCLKO=spiflash_pads.clk, i_USRCCLKTS=0, i_USRDONEO=1, i_USRDONETS=1)
         spiflash_dummy = {
             "spiflash_1x": 9,
             "spiflash_4x": 11,
         }
         self.submodules.spiflash = spi_flash.SpiFlash(
-                spiflash_pads,
-                dummy=spiflash_dummy[spiflash],
-                div=2)
-        self.add_constant("SPIFLASH_PAGE_SIZE", 256)
-        self.add_constant("SPIFLASH_SECTOR_SIZE", 0x10000)
-        self.add_wb_slave(mem_decoder(self.mem_map["spiflash"]), self.spiflash.bus)
+            spiflash_pads,
+            dummy=spiflash_dummy[spiflash],
+            div=2,
+            endianness=self.cpu.endianness)
+        self.add_csr("spiflash")
+        self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
+        self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
+        self.add_constant("SPIFLASH_TOTAL_SIZE", platform.spiflash_total_size)
+        self.add_wb_slave(
+            self.mem_map["spiflash"],
+            self.spiflash.bus,
+            platform.spiflash_total_size)
         self.add_memory_region(
-            "spiflash", self.mem_map["spiflash"], 16*1024*1024)
+            "spiflash",
+            self.mem_map["spiflash"],
+            platform.spiflash_total_size)
+
+        bios_size = 0x8000
+        self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
+
+        # Support for soft-emulation for full Linux support ----------------------------------------
+        if self.cpu_type == "vexriscv" and self.cpu_variant == "linux":
+            size = 0x4000
+            self.submodules.emulator_ram = wishbone.SRAM(size)
+            self.register_mem("emulator_ram", self.mem_map["emulator_ram"], self.emulator_ram.bus, size)
 
 
 SoC = BaseSoC

--- a/targets/mimas_a7/crg.py
+++ b/targets/mimas_a7/crg.py
@@ -1,0 +1,67 @@
+# Support for Numato Mimas A7 board
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq):
+        self.clock_domains.cd_sys = ClockDomain()
+        self.clock_domains.cd_sys4x = ClockDomain(reset_less=True)
+        self.clock_domains.cd_sys4x_dqs = ClockDomain(reset_less=True)
+        self.clock_domains.cd_clk200 = ClockDomain()
+        self.clock_domains.cd_clk100 = ClockDomain()
+
+        clk100 = platform.request("clk100")
+        rst = platform.request("cpu_reset")
+
+        pll_locked = Signal()
+        pll_fb = Signal()
+        self.pll_sys = Signal()
+        pll_sys4x = Signal()
+        pll_sys4x_dqs = Signal()
+        pll_clk200 = Signal()
+        self.specials += [
+            Instance("PLLE2_BASE",
+                     p_STARTUP_WAIT="FALSE", o_LOCKED=pll_locked,
+
+                     # VCO @ 1600 MHz
+                     p_REF_JITTER1=0.01, p_CLKIN1_PERIOD=10.0,
+                     p_CLKFBOUT_MULT=16, p_DIVCLK_DIVIDE=1,
+                     i_CLKIN1=clk100, i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb,
+
+                     # 100 MHz
+                     p_CLKOUT0_DIVIDE=16, p_CLKOUT0_PHASE=0.0,
+                     o_CLKOUT0=self.pll_sys,
+
+                     # 400 MHz
+                     p_CLKOUT1_DIVIDE=4, p_CLKOUT1_PHASE=0.0,
+                     o_CLKOUT1=pll_sys4x,
+
+                     # 400 MHz dqs
+                     p_CLKOUT2_DIVIDE=4, p_CLKOUT2_PHASE=90.0,
+                     o_CLKOUT2=pll_sys4x_dqs,
+
+                     # 200 MHz
+                     p_CLKOUT3_DIVIDE=8, p_CLKOUT3_PHASE=0.0,
+                     o_CLKOUT3=pll_clk200
+            ),
+            Instance("BUFG", i_I=self.pll_sys, o_O=self.cd_sys.clk),
+            Instance("BUFG", i_I=pll_sys4x, o_O=self.cd_sys4x.clk),
+            Instance("BUFG", i_I=pll_sys4x_dqs, o_O=self.cd_sys4x_dqs.clk),
+            Instance("BUFG", i_I=pll_clk200, o_O=self.cd_clk200.clk),
+            Instance("BUFG", i_I=clk100, o_O=self.cd_clk100.clk),
+            AsyncResetSynchronizer(self.cd_sys, ~pll_locked | rst),
+            AsyncResetSynchronizer(self.cd_clk200, ~pll_locked | rst),
+            AsyncResetSynchronizer(self.cd_clk100, ~pll_locked | rst),
+        ]
+
+        reset_counter = Signal(4, reset=15)
+        ic_reset = Signal(reset=1)
+        self.sync.clk200 += \
+            If(reset_counter != 0,
+                reset_counter.eq(reset_counter - 1)
+            ).Else(
+                ic_reset.eq(0)
+            )
+        self.specials += Instance("IDELAYCTRL", i_REFCLK=ClockSignal("clk200"), i_RST=ic_reset)

--- a/targets/mimas_a7/net.py
+++ b/targets/mimas_a7/net.py
@@ -1,37 +1,42 @@
-from litex.soc.integration.soc_core import mem_decoder
 from litex.soc.integration.soc_sdram import *
 
 from liteeth.core.mac import LiteEthMAC
-from liteeth.phy.s7rgmii import LiteEthPHYRGMII
+from liteeth.phy import LiteEthPHY
 
-from targets.utils import csr_map_update
-from targets.mimas_a7.base import SoC as BaseSoC
+from .base import BaseSoC
 
 
 class NetSoC(BaseSoC):
-    csr_peripherals = (
-        "ethphy",
-        "ethmac",
-    )
-    csr_map_update(BaseSoC.csr_map, csr_peripherals)
-
-    mem_map = {
-        "ethmac": 0x30000000,  # (shadow @0xb0000000)
-    }
-    mem_map.update(BaseSoC.mem_map)
+    mem_map = {**BaseSoC.mem_map, **{
+        "ethmac": 0xb0000000,
+    }}
 
     def __init__(self, platform, *args, **kwargs):
+        # Need a larger integrated ROM on or1k to fit the BIOS with TFTP support.
+        if 'integrated_rom_size' not in kwargs and kwargs.get('cpu_type', 'lm32') != 'lm32':
+            kwargs['integrated_rom_size'] = 0x10000
+
         BaseSoC.__init__(self, platform, *args, **kwargs)
 
-        self.submodules.ethphy = LiteEthPHYRGMII(
+        # Ethernet ---------------------------------------------------------------------------------
+        # Ethernet PHY
+        self.submodules.ethphy = LiteEthPHY(
             platform.request("eth_clocks"),
             platform.request("eth"))
-        self.submodules.ethmac = LiteEthMAC(
-            phy=self.ethphy, dw=32, interface="wishbone", endianness=self.cpu.endianness)
-        self.add_wb_slave(mem_decoder(self.mem_map["ethmac"]), self.ethmac.bus)
-        self.add_memory_region("ethmac",
-            self.mem_map["ethmac"] | self.shadow_base, 0x2000)
+        self.add_csr("ethphy")
 
+        # Ethernet MAC
+        ethmac_win_size = 0x2000
+        self.submodules.ethmac = LiteEthMAC(
+            phy        = self.ethphy,
+            dw         = 32,
+            interface  = "wishbone",
+            endianness = self.cpu.endianness)
+        self.add_wb_slave(self.mem_map["ethmac"], self.ethmac.bus, ethmac_win_size)
+        self.add_memory_region("ethmac", self.mem_map["ethmac"], ethmac_win_size, type="io")
+        self.add_csr("ethmac")
+        self.add_interrupt("ethmac")
+        # timing constraints
         self.ethphy.crg.cd_eth_rx.clk.attr.add("keep")
         self.ethphy.crg.cd_eth_tx.clk.attr.add("keep")
         #self.platform.add_period_constraint(self.crg.cd_sys.clk, 10.0)
@@ -41,8 +46,6 @@ class NetSoC(BaseSoC):
             self.crg.cd_sys.clk,
             self.ethphy.crg.cd_eth_rx.clk,
             self.ethphy.crg.cd_eth_tx.clk)
-
-        self.add_interrupt("ethmac")
 
     def configure_iprange(self, iprange):
         iprange = [int(x) for x in iprange.split(".")]

--- a/targets/mimas_a7/net.py
+++ b/targets/mimas_a7/net.py
@@ -1,7 +1,7 @@
 from litex.soc.integration.soc_sdram import *
 
 from liteeth.core.mac import LiteEthMAC
-from liteeth.phy import LiteEthPHY
+from liteeth.phy.s7rgmii import LiteEthPHYRGMII
 
 from .base import BaseSoC
 
@@ -20,7 +20,7 @@ class NetSoC(BaseSoC):
 
         # Ethernet ---------------------------------------------------------------------------------
         # Ethernet PHY
-        self.submodules.ethphy = LiteEthPHY(
+        self.submodules.ethphy = LiteEthPHYRGMII(
             platform.request("eth_clocks"),
             platform.request("eth"))
         self.add_csr("ethphy")

--- a/targets/mimasv2/base.py
+++ b/targets/mimasv2/base.py
@@ -1,4 +1,8 @@
 # Support for the MimasV2
+
+import os
+from fractions import Fraction
+
 from migen import *
 
 from litex.soc.integration.soc_sdram import *
@@ -63,7 +67,7 @@ class BaseSoC(SoCSDRAM):
         # Basic peripherals ------------------------------------------------------------------------
         self.submodules.info = info.Info(platform, self.__class__.__name__)
         self.add_csr("info")
-        self.submodules.cas = cas.ControlAndStatus(platform, clk_freq)
+        self.submodules.cas = cas.ControlAndStatus(platform, sys_clk_freq)
         self.add_csr("cas")
 
         # Add debug interface if the CPU has one ---------------------------------------------------

--- a/targets/mimasv2/base.py
+++ b/targets/mimasv2/base.py
@@ -1,11 +1,5 @@
 # Support for the MimasV2
-
-import os
-
-from fractions import Fraction
-
 from migen import *
-from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
@@ -14,185 +8,21 @@ from litedram.modules import MT46H32M16
 from litedram.phy import s6ddrphy
 from litedram.core import ControllerSettings
 
-from gateware import info
 from gateware import cas
+from gateware import info
 from gateware import spi_flash
 
-from targets.utils import csr_map_update
-
-
-class _CRG(Module):
-    def __init__(self, platform, clk_freq):
-        # Clock domains for the system (soft CPU and related components run at).
-        self.clock_domains.cd_sys = ClockDomain()
-        # Clock domains for the DDR interface.
-        self.clock_domains.cd_sdram_half = ClockDomain()
-        self.clock_domains.cd_sdram_full_wr = ClockDomain()
-        self.clock_domains.cd_sdram_full_rd = ClockDomain()
-        # Clock domain for peripherals (such as HDMI output).
-        self.clock_domains.cd_base50 = ClockDomain()
-
-        self.reset = Signal()
-
-        # Input 100MHz clock
-        f0 = 100*1000000
-        clk100 = platform.request("clk100")
-        clk100a = Signal()
-        # Input 100MHz clock (buffered)
-        self.specials += Instance("IBUFG", i_I=clk100, o_O=clk100a)
-        clk100b = Signal()
-        self.specials += Instance(
-            "BUFIO2", p_DIVIDE=1,
-            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
-            i_I=clk100a, o_DIVCLK=clk100b)
-
-        p = 8
-        f = Fraction(clk_freq*p, f0)
-        n, d = f.numerator, f.denominator
-        assert 19e6 <= f0/d <= 500e6  # pfd
-        assert 400e6 <= f0*n/d <= 1080e6  # vco
-
-        # Unbuffered output signals from the PLL. They need to be buffered
-        # before feeding into the fabric.
-        unbuf_sdram_full = Signal()
-        unbuf_sdram_half_a = Signal()
-        unbuf_sdram_half_b = Signal()
-        unbuf_unused = Signal()
-        unbuf_sys = Signal()
-        unbuf_periph = Signal()
-
-        # PLL signals
-        pll_lckd = Signal()
-        pll_fb = Signal()
-        self.specials.pll = Instance(
-            "PLL_ADV",
-            name="crg_pll_adv",
-            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
-            p_REF_JITTER=.01,
-            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
-            p_DIVCLK_DIVIDE=d,
-            # Input Clocks (100MHz)
-            i_CLKIN1=clk100b,
-            p_CLKIN1_PERIOD=1e9/f0,
-            i_CLKIN2=0,
-            p_CLKIN2_PERIOD=0.,
-            i_CLKINSEL=1,
-            # Feedback
-            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
-            p_CLK_FEEDBACK="CLKFBOUT",
-            p_CLKFBOUT_MULT=n, p_CLKFBOUT_PHASE=0.,
-            # (333MHz) sdram wr rd
-            o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
-            p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//4,
-            # unused?
-            o_CLKOUT1=unbuf_unused, p_CLKOUT1_DUTY_CYCLE=.5,
-            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=p//4,
-            # (???MHz) sdram_half - sdram dqs adr ctrl
-            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
-            p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=p//2,
-            # (????Hz) off-chip ddr
-            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
-            p_CLKOUT3_PHASE=270., p_CLKOUT3_DIVIDE=p//2,
-            # ( 50MHz) periph
-            o_CLKOUT4=unbuf_periph, p_CLKOUT4_DUTY_CYCLE=.5,
-            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=p//1,
-            # ( ??MHz) sysclk
-            o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
-            p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=p//1,
-        )
-
-
-        # power on reset?
-        reset = ~platform.request("user_btn", 5) | self.reset
-        self.clock_domains.cd_por = ClockDomain()
-        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
-        self.sync.por += If(por != 0, por.eq(por - 1))
-        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
-
-        # System clock - ??MHz
-        self.specials += Instance("BUFG", name="sys_bufg", i_I=unbuf_sys, o_O=self.cd_sys.clk)
-        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
-        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
-
-        # SDRAM clocks
-        # ------------------------------------------------------------------------------
-        self.clk4x_wr_strb = Signal()
-        self.clk4x_rd_strb = Signal()
-
-        # sdram_full
-        self.specials += Instance("BUFPLL", name="sdram_full_bufpll",
-                                  p_DIVIDE=4,
-                                  i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys.clk,
-                                  i_LOCKED=pll_lckd,
-                                  o_IOCLK=self.cd_sdram_full_wr.clk,
-                                  o_SERDESSTROBE=self.clk4x_wr_strb)
-        self.comb += [
-            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
-            self.clk4x_rd_strb.eq(self.clk4x_wr_strb),
-        ]
-        # sdram_half
-        self.specials += Instance("BUFG", name="sdram_half_a_bufpll", i_I=unbuf_sdram_half_a, o_O=self.cd_sdram_half.clk)
-        clk_sdram_half_shifted = Signal()
-        self.specials += Instance("BUFG", name="sdram_half_b_bufpll", i_I=unbuf_sdram_half_b, o_O=clk_sdram_half_shifted)
-        clk = platform.request("ddram_clock")
-        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
-                                  p_INIT=0, p_SRTYPE="SYNC",
-                                  i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
-                                  i_C0=clk_sdram_half_shifted,
-                                  i_C1=~clk_sdram_half_shifted,
-                                  o_Q=clk.p)
-        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
-                                  p_INIT=0, p_SRTYPE="SYNC",
-                                  i_D0=0, i_D1=1, i_S=0, i_R=0, i_CE=1,
-                                  i_C0=clk_sdram_half_shifted, i_C1=~clk_sdram_half_shifted,
-                                  o_Q=clk.n)
-
-        # Peripheral clock - 50MHz
-        # ------------------------------------------------------------------------------
-        # The peripheral clock is kept separate from the system clock to allow
-        # the system clock to be increased in the future.
-        dcm_base50_locked = Signal()
-        self.specials += [
-            Instance("DCM_CLKGEN", name="crg_periph_dcm_clkgen",
-                     p_CLKIN_PERIOD=10.0,
-                     p_CLKFX_MULTIPLY=2,
-                     p_CLKFX_DIVIDE=4,
-                     p_CLKFX_MD_MAX=0.5, # CLKFX_MULTIPLY/CLKFX_DIVIDE
-                     p_CLKFXDV_DIVIDE=2,
-                     p_SPREAD_SPECTRUM="NONE",
-                     p_STARTUP_WAIT="FALSE",
-
-                     i_CLKIN=clk100a,
-                     o_CLKFX=self.cd_base50.clk,
-                     o_LOCKED=dcm_base50_locked,
-                     i_FREEZEDCM=0,
-                     i_RST=ResetSignal(),
-                     ),
-            AsyncResetSynchronizer(self.cd_base50,
-                self.cd_sys.rst | ~dcm_base50_locked)
-        ]
-        platform.add_period_constraint(self.cd_base50.clk, 20)
+from .crg import _CRG
 
 
 class BaseSoC(SoCSDRAM):
-    csr_peripherals = (
-        "spiflash",
-        "ddrphy",
-        "info",
-        "cas",
-    )
-    csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
-
-    mem_map = {
-        "spiflash": 0x20000000,  # (default shadow @0xa0000000)
-    }
-    mem_map.update(SoCSDRAM.mem_map)
+    mem_map = {**SoCSDRAM.mem_map, **{
+        'spiflash': 0x20000000,
+    }}
 
     def __init__(self, platform, **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=None
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x4000
+        kwargs['integrated_rom_size']=None
+        kwargs['integrated_sram_size']=0x4000
 
         kwargs['cpu_reset_address']=self.mem_map["spiflash"]+platform.gateware_size
         if os.environ.get('JIMMO', '0') == '0':
@@ -200,25 +30,68 @@ class BaseSoC(SoCSDRAM):
         else:
             kwargs['uart_baudrate']=115200
 
-        clk_freq = (83 + Fraction(1, 3))*1000*1000
-        SoCSDRAM.__init__(self, platform, clk_freq, **kwargs)
+        sys_clk_freq = (83 + Fraction(1, 3))*1000*1000
+        # SoCSDRAM ---------------------------------------------------------------------------------
+        SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq, **kwargs)
 
-        self.submodules.crg = _CRG(platform, clk_freq)
-        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/clk_freq)
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/sys_clk_freq)
 
-        # Basic peripherals
+        # DDR2 SDRAM -------------------------------------------------------------------------------
+        if True:
+            sdram_module = MT46H32M16(self.clk_freq, "1:2")
+            self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
+                platform.request("ddram"),
+                memtype      = sdram_module.memtype,
+                rd_bitslip   = 1,
+                wr_bitslip   = 3,
+                dqs_ddr_alignment="C1")
+            self.add_csr("ddrphy")
+            controller_settings = ControllerSettings(
+                with_bandwidth=True)
+            self.register_sdram(
+                self.ddrphy,
+                geom_settings   = sdram_module.geom_settings,
+                timing_settings = sdram_module.timing_settings,
+                controller_settings=controller_settings)
+            self.comb += [
+                self.ddrphy.clk4x_wr_strb.eq(self.crg.clk4x_wr_strb),
+                self.ddrphy.clk4x_rd_strb.eq(self.crg.clk4x_rd_strb),
+            ]
+
+        # Basic peripherals ------------------------------------------------------------------------
         self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.add_csr("info")
         self.submodules.cas = cas.ControlAndStatus(platform, clk_freq)
+        self.add_csr("cas")
 
-        # spi flash
+        # Add debug interface if the CPU has one ---------------------------------------------------
+        if hasattr(self.cpu, "debug_bus"):
+            self.register_mem(
+                name="vexriscv_debug",
+                address=0xf00f0000,
+                interface=self.cpu.debug_bus,
+                size=0x100)
+
+        # Memory mapped SPI Flash ------------------------------------------------------------------
         self.submodules.spiflash = spi_flash.SpiFlashSingle(
             platform.request("spiflash"),
             dummy=platform.spiflash_read_dummy_bits,
-            div=platform.spiflash_clock_div)
+            div=platform.spiflash_clock_div,
+            endianness=self.cpu.endianness)
+        self.add_csr("spiflash")
         self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
         self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
-        self.register_mem("spiflash", self.mem_map["spiflash"],
-            self.spiflash.bus, size=platform.spiflash_total_size)
+        self.add_constant("SPIFLASH_TOTAL_SIZE", platform.spiflash_total_size)
+        self.add_wb_slave(
+            self.mem_map["spiflash"],
+            self.spiflash.bus,
+            platform.spiflash_total_size)
+        self.add_memory_region(
+            "spiflash",
+            self.mem_map["spiflash"],
+            platform.spiflash_total_size)
 
         bios_size = 0x8000
         self.add_constant("ROM_DISABLE", 1)
@@ -228,23 +101,5 @@ class BaseSoC(SoCSDRAM):
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
         self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
 
-        # sdram
-        sdram_module = MT46H32M16(self.clk_freq, "1:2")
-        self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
-            platform.request("ddram"),
-            sdram_module.memtype,
-            rd_bitslip=1,
-            wr_bitslip=3,
-            dqs_ddr_alignment="C1")
-        controller_settings = ControllerSettings(
-            with_bandwidth=True)
-        self.register_sdram(self.ddrphy,
-                            sdram_module.geom_settings,
-                            sdram_module.timing_settings,
-                            controller_settings=controller_settings)
-        self.comb += [
-            self.ddrphy.clk4x_wr_strb.eq(self.crg.clk4x_wr_strb),
-            self.ddrphy.clk4x_rd_strb.eq(self.crg.clk4x_rd_strb),
-        ]
 
 SoC = BaseSoC

--- a/targets/mimasv2/crg.py
+++ b/targets/mimasv2/crg.py
@@ -1,0 +1,159 @@
+# Support for the MimasV2
+
+from fractions import Fraction
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+
+class _CRG(Module):
+    def __init__(self, platform, clk_freq):
+        # Clock domains for the system (soft CPU and related components run at).
+        self.clock_domains.cd_sys = ClockDomain()
+        # Clock domains for the DDR interface.
+        self.clock_domains.cd_sdram_half = ClockDomain()
+        self.clock_domains.cd_sdram_full_wr = ClockDomain()
+        self.clock_domains.cd_sdram_full_rd = ClockDomain()
+        # Clock domain for peripherals (such as HDMI output).
+        self.clock_domains.cd_base50 = ClockDomain()
+
+        self.reset = Signal()
+
+        # Input 100MHz clock
+        f0 = 100*1000000
+        clk100 = platform.request("clk100")
+        clk100a = Signal()
+        # Input 100MHz clock (buffered)
+        self.specials += Instance("IBUFG", i_I=clk100, o_O=clk100a)
+        clk100b = Signal()
+        self.specials += Instance(
+            "BUFIO2", p_DIVIDE=1,
+            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
+            i_I=clk100a, o_DIVCLK=clk100b)
+
+        p = 8
+        f = Fraction(clk_freq*p, f0)
+        n, d = f.numerator, f.denominator
+        assert 19e6 <= f0/d <= 500e6  # pfd
+        assert 400e6 <= f0*n/d <= 1080e6  # vco
+
+        # Unbuffered output signals from the PLL. They need to be buffered
+        # before feeding into the fabric.
+        unbuf_sdram_full = Signal()
+        unbuf_sdram_half_a = Signal()
+        unbuf_sdram_half_b = Signal()
+        unbuf_unused = Signal()
+        unbuf_sys = Signal()
+        unbuf_periph = Signal()
+
+        # PLL signals
+        pll_lckd = Signal()
+        pll_fb = Signal()
+        self.specials.pll = Instance(
+            "PLL_ADV",
+            name="crg_pll_adv",
+            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
+            p_REF_JITTER=.01,
+            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
+            p_DIVCLK_DIVIDE=d,
+            # Input Clocks (100MHz)
+            i_CLKIN1=clk100b,
+            p_CLKIN1_PERIOD=1e9/f0,
+            i_CLKIN2=0,
+            p_CLKIN2_PERIOD=0.,
+            i_CLKINSEL=1,
+            # Feedback
+            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
+            p_CLK_FEEDBACK="CLKFBOUT",
+            p_CLKFBOUT_MULT=n, p_CLKFBOUT_PHASE=0.,
+            # (333MHz) sdram wr rd
+            o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
+            p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//4,
+            # unused?
+            o_CLKOUT1=unbuf_unused, p_CLKOUT1_DUTY_CYCLE=.5,
+            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=p//4,
+            # (???MHz) sdram_half - sdram dqs adr ctrl
+            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
+            p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=p//2,
+            # (????Hz) off-chip ddr
+            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
+            p_CLKOUT3_PHASE=270., p_CLKOUT3_DIVIDE=p//2,
+            # ( 50MHz) periph
+            o_CLKOUT4=unbuf_periph, p_CLKOUT4_DUTY_CYCLE=.5,
+            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=p//1,
+            # ( ??MHz) sysclk
+            o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
+            p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=p//1,
+        )
+
+
+        # power on reset?
+        reset = ~platform.request("user_btn", 5) | self.reset
+        self.clock_domains.cd_por = ClockDomain()
+        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
+        self.sync.por += If(por != 0, por.eq(por - 1))
+        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
+
+        # System clock - ??MHz
+        self.specials += Instance("BUFG", name="sys_bufg", i_I=unbuf_sys, o_O=self.cd_sys.clk)
+        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
+
+        # SDRAM clocks
+        # ------------------------------------------------------------------------------
+        self.clk4x_wr_strb = Signal()
+        self.clk4x_rd_strb = Signal()
+
+        # sdram_full
+        self.specials += Instance("BUFPLL", name="sdram_full_bufpll",
+                                  p_DIVIDE=4,
+                                  i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys.clk,
+                                  i_LOCKED=pll_lckd,
+                                  o_IOCLK=self.cd_sdram_full_wr.clk,
+                                  o_SERDESSTROBE=self.clk4x_wr_strb)
+        self.comb += [
+            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
+            self.clk4x_rd_strb.eq(self.clk4x_wr_strb),
+        ]
+        # sdram_half
+        self.specials += Instance("BUFG", name="sdram_half_a_bufpll", i_I=unbuf_sdram_half_a, o_O=self.cd_sdram_half.clk)
+        clk_sdram_half_shifted = Signal()
+        self.specials += Instance("BUFG", name="sdram_half_b_bufpll", i_I=unbuf_sdram_half_b, o_O=clk_sdram_half_shifted)
+        clk = platform.request("ddram_clock")
+        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
+                                  p_INIT=0, p_SRTYPE="SYNC",
+                                  i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
+                                  i_C0=clk_sdram_half_shifted,
+                                  i_C1=~clk_sdram_half_shifted,
+                                  o_Q=clk.p)
+        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
+                                  p_INIT=0, p_SRTYPE="SYNC",
+                                  i_D0=0, i_D1=1, i_S=0, i_R=0, i_CE=1,
+                                  i_C0=clk_sdram_half_shifted, i_C1=~clk_sdram_half_shifted,
+                                  o_Q=clk.n)
+
+        # Peripheral clock - 50MHz
+        # ------------------------------------------------------------------------------
+        # The peripheral clock is kept separate from the system clock to allow
+        # the system clock to be increased in the future.
+        dcm_base50_locked = Signal()
+        self.specials += [
+            Instance("DCM_CLKGEN", name="crg_periph_dcm_clkgen",
+                     p_CLKIN_PERIOD=10.0,
+                     p_CLKFX_MULTIPLY=2,
+                     p_CLKFX_DIVIDE=4,
+                     p_CLKFX_MD_MAX=0.5, # CLKFX_MULTIPLY/CLKFX_DIVIDE
+                     p_CLKFXDV_DIVIDE=2,
+                     p_SPREAD_SPECTRUM="NONE",
+                     p_STARTUP_WAIT="FALSE",
+
+                     i_CLKIN=clk100a,
+                     o_CLKFX=self.cd_base50.clk,
+                     o_LOCKED=dcm_base50_locked,
+                     i_FREEZEDCM=0,
+                     i_RST=ResetSignal(),
+                     ),
+            AsyncResetSynchronizer(self.cd_base50,
+                self.cd_sys.rst | ~dcm_base50_locked)
+        ]
+        platform.add_period_constraint(self.cd_base50.clk, 20)

--- a/targets/mimasv2/scope.py
+++ b/targets/mimasv2/scope.py
@@ -8,17 +8,10 @@ from litescope import LiteScopeIO
 
 from gateware.memtest import LiteDRAMBISTCheckerScope
 
-from targets.utils import csr_map_update
 from targets.mimasv2.base import BaseSoC
 
 
 class MemTestSoC(BaseSoC):
-    csr_peripherals = (
-        "analyzer",
-        "io",
-    )
-    csr_map_update(BaseSoC.csr_map, csr_peripherals)
-
     def __init__(self, platform, *args, **kwargs):
         kwargs['cpu_type'] = None
         BaseSoC.__init__(self, platform, *args, with_uart=False, **kwargs)
@@ -34,6 +27,7 @@ class MemTestSoC(BaseSoC):
                 self.comb += platform.request("user_led", i).eq(self.io.output[i])
             except:
                 pass
+        self.add_csr("io")
 
         analyzer_signals = [
             self.spiflash.bus,
@@ -44,6 +38,7 @@ class MemTestSoC(BaseSoC):
         #    self.spiflash.sr,
         ]
         self.submodules.analyzer = LiteScopeAnalyzer(analyzer_signals, 1024)
+        self.add_csr("analyzer")
 
     def do_exit(self, vns, filename="test/analyzer.csv"):
         self.analyzer.export_csv(vns, filename)

--- a/targets/minispartan6/base.py
+++ b/targets/minispartan6/base.py
@@ -1,9 +1,5 @@
 # Support for the MiniSpartan6+ - https://www.scarabhardware.com/minispartan6/
-from fractions import Fraction
-
 from migen import *
-from migen.genlib.io import CRG
-from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
@@ -12,112 +8,81 @@ from litedram.modules import AS4C16M16
 from litedram.phy import gensdrphy
 from litedram.core import ControllerSettings
 
-from gateware import info
 from gateware import cas
+from gateware import info
 from gateware import spi_flash
 
-from targets.utils import csr_map_update
+from .crg import _CRG
 
-
-class _CRG(Module):
-    def __init__(self, platform, clk_freq):
-        self.clock_domains.cd_sys = ClockDomain()
-        self.clock_domains.cd_sys_ps = ClockDomain()
-
-        f0 = 32*1000000
-        clk32 = platform.request("clk32")
-        clk32a = Signal()
-        self.specials += Instance("IBUFG", i_I=clk32, o_O=clk32a)
-        clk32b = Signal()
-        self.specials += Instance("BUFIO2", p_DIVIDE=1,
-                                  p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
-                                  i_I=clk32a, o_DIVCLK=clk32b)
-        f = Fraction(int(clk_freq), int(f0))
-        n, m, p = f.denominator, f.numerator, 8
-        assert f0/n*m == clk_freq
-        pll_lckd = Signal()
-        pll_fb = Signal()
-        pll = Signal(6)
-        self.specials.pll = Instance("PLL_ADV", p_SIM_DEVICE="SPARTAN6",
-                                     p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
-                                     p_REF_JITTER=.01, p_CLK_FEEDBACK="CLKFBOUT",
-                                     i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
-                                     p_DIVCLK_DIVIDE=1, p_CLKFBOUT_MULT=m*p//n, p_CLKFBOUT_PHASE=0.,
-                                     i_CLKIN1=clk32b, i_CLKIN2=0, i_CLKINSEL=1,
-                                     p_CLKIN1_PERIOD=1000000000/f0, p_CLKIN2_PERIOD=0.,
-                                     i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
-                                     o_CLKOUT0=pll[0], p_CLKOUT0_DUTY_CYCLE=.5,
-                                     o_CLKOUT1=pll[1], p_CLKOUT1_DUTY_CYCLE=.5,
-                                     o_CLKOUT2=pll[2], p_CLKOUT2_DUTY_CYCLE=.5,
-                                     o_CLKOUT3=pll[3], p_CLKOUT3_DUTY_CYCLE=.5,
-                                     o_CLKOUT4=pll[4], p_CLKOUT4_DUTY_CYCLE=.5,
-                                     o_CLKOUT5=pll[5], p_CLKOUT5_DUTY_CYCLE=.5,
-                                     p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//1,
-                                     p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=p//1,
-                                     p_CLKOUT2_PHASE=0., p_CLKOUT2_DIVIDE=p//1,
-                                     p_CLKOUT3_PHASE=0., p_CLKOUT3_DIVIDE=p//1,
-                                     p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=p//1,  # sys
-                                     p_CLKOUT5_PHASE=270., p_CLKOUT5_DIVIDE=p//1,  # sys_ps
-        )
-        self.specials += Instance("BUFG", i_I=pll[4], o_O=self.cd_sys.clk)
-        self.specials += Instance("BUFG", i_I=pll[5], o_O=self.cd_sys_ps.clk)
-        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd)
-
-        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
-                                  p_INIT=0, p_SRTYPE="SYNC",
-                                  i_D0=0, i_D1=1, i_S=0, i_R=0, i_CE=1,
-                                  i_C0=self.cd_sys.clk, i_C1=~self.cd_sys.clk,
-                                  o_Q=platform.request("sdram_clock"))
 
 class BaseSoC(SoCSDRAM):
-    csr_peripherals = (
-        "spiflash",
-        "cas",
-        "ddrphy",
-        "info",
-    )
-    csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
-
-    mem_map = {
-        "spiflash": 0x20000000,  # (default shadow @0xa0000000)
-    }
-    mem_map.update(SoCSDRAM.mem_map)
+    mem_map = {**SoCSDRAM.mem_map, **{
+        'spiflash': 0x20000000,
+    }}
 
     def __init__(self, platform, **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0x8000
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x4000
+        kwargs['integrated_rom_size']=0x8000
+        kwargs['integrated_sram_size']=0x4000
 
-        clk_freq = 80*1000000
+        sys_clk_freq = 80*1000000
+        # SoCSDRAM ---------------------------------------------------------------------------------
         SoCSDRAM.__init__(self, platform, clk_freq, **kwargs)
 
-        self.submodules.crg = _CRG(platform, clk_freq)
-        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/clk_freq)
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/sys_clk_freq)
 
-        # Basic peripherals
+        # DDR2 SDRAM -------------------------------------------------------------------------------
+        if True:
+            sdram_module = AS4C16M16(self.clk_freq, "1:1")
+            self.submodules.ddrphy = gensdrphy.GENSDRPHY(
+                platform.request("sdram"))
+            self.add_csr("ddrphy")
+            self.register_sdram(
+                self.ddrphy,
+                geom_settings   = sdram_module.geom_settings,
+                timing_settings = sdram_module.timing_settings)
 
-
+        # Basic peripherals ------------------------------------------------------------------------
         self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.add_csr("info")
         self.submodules.cas = cas.ControlAndStatus(platform, clk_freq)
+        self.add_csr("cas")
 
+        # Add debug interface if the CPU has one ---------------------------------------------------
+        if hasattr(self.cpu, "debug_bus"):
+            self.register_mem(
+                name="vexriscv_debug",
+                address=0xf00f0000,
+                interface=self.cpu.debug_bus,
+                size=0x100)
 
+        # Memory mapped SPI Flash ------------------------------------------------------------------
         self.submodules.spiflash = spi_flash.SpiFlash(
             platform.request("spiflash2x"),
             dummy=platform.spiflash_read_dummy_bits,
-            div=platform.spiflash_clock_div)
+            div=platform.spiflash_clock_div,
+            endianness=self.cpu.endianness)
+        self.add_csr("spiflash")
         self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
         self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
-        self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size
-        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
-        self.register_mem("spiflash", self.mem_map["spiflash"],
-            self.spiflash.bus, size=platform.spiflash_total_size)
+        self.add_constant("SPIFLASH_TOTAL_SIZE", platform.spiflash_total_size)
+        self.add_wb_slave(
+            self.mem_map["spiflash"],
+            self.spiflash.bus,
+            platform.spiflash_total_size)
+        self.add_memory_region(
+            "spiflash",
+            self.mem_map["spiflash"],
+            platform.spiflash_total_size)
 
-        # sdram
-        sdram_module = AS4C16M16(self.clk_freq, "1:1")
-        self.submodules.ddrphy = gensdrphy.GENSDRPHY(platform.request("sdram"))
-        self.register_sdram(self.ddrphy,
-                            sdram_module.geom_settings,
-                            sdram_module.timing_settings)
+        bios_size = 0x8000
+        self.add_constant("ROM_DISABLE", 1)
+        self.add_memory_region(
+            "rom", kwargs['cpu_reset_address'], bios_size,
+            type="cached+linker")
+        self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
+
 
 SoC = BaseSoC

--- a/targets/minispartan6/base.py
+++ b/targets/minispartan6/base.py
@@ -21,12 +21,14 @@ class BaseSoC(SoCSDRAM):
     }}
 
     def __init__(self, platform, **kwargs):
-        kwargs['integrated_rom_size']=0x8000
+        kwargs['integrated_rom_size']=None
         kwargs['integrated_sram_size']=0x4000
+
+        kwargs['cpu_reset_address']=self.mem_map["spiflash"]+platform.gateware_size
 
         sys_clk_freq = 80*1000000
         # SoCSDRAM ---------------------------------------------------------------------------------
-        SoCSDRAM.__init__(self, platform, clk_freq, **kwargs)
+        SoCSDRAM.__init__(self, platform, sys_clk_freq, **kwargs)
 
         # CRG --------------------------------------------------------------------------------------
         self.submodules.crg = _CRG(platform, sys_clk_freq)
@@ -34,7 +36,7 @@ class BaseSoC(SoCSDRAM):
 
         # DDR2 SDRAM -------------------------------------------------------------------------------
         if True:
-            sdram_module = AS4C16M16(self.clk_freq, "1:1")
+            sdram_module = AS4C16M16(sys_clk_freq, "1:1")
             self.submodules.ddrphy = gensdrphy.GENSDRPHY(
                 platform.request("sdram"))
             self.add_csr("ddrphy")
@@ -46,7 +48,7 @@ class BaseSoC(SoCSDRAM):
         # Basic peripherals ------------------------------------------------------------------------
         self.submodules.info = info.Info(platform, self.__class__.__name__)
         self.add_csr("info")
-        self.submodules.cas = cas.ControlAndStatus(platform, clk_freq)
+        self.submodules.cas = cas.ControlAndStatus(platform, sys_clk_freq)
         self.add_csr("cas")
 
         # Add debug interface if the CPU has one ---------------------------------------------------

--- a/targets/minispartan6/crg.py
+++ b/targets/minispartan6/crg.py
@@ -1,0 +1,57 @@
+# Support for the MiniSpartan6+ - https://www.scarabhardware.com/minispartan6/
+
+from fractions import Fraction
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+
+class _CRG(Module):
+    def __init__(self, platform, clk_freq):
+        self.clock_domains.cd_sys = ClockDomain()
+        self.clock_domains.cd_sys_ps = ClockDomain()
+
+        f0 = 32*1000000
+        clk32 = platform.request("clk32")
+        clk32a = Signal()
+        self.specials += Instance("IBUFG", i_I=clk32, o_O=clk32a)
+        clk32b = Signal()
+        self.specials += Instance("BUFIO2", p_DIVIDE=1,
+                                  p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
+                                  i_I=clk32a, o_DIVCLK=clk32b)
+        f = Fraction(int(clk_freq), int(f0))
+        n, m, p = f.denominator, f.numerator, 8
+        assert f0/n*m == clk_freq
+        pll_lckd = Signal()
+        pll_fb = Signal()
+        pll = Signal(6)
+        self.specials.pll = Instance("PLL_ADV", p_SIM_DEVICE="SPARTAN6",
+                                     p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
+                                     p_REF_JITTER=.01, p_CLK_FEEDBACK="CLKFBOUT",
+                                     i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
+                                     p_DIVCLK_DIVIDE=1, p_CLKFBOUT_MULT=m*p//n, p_CLKFBOUT_PHASE=0.,
+                                     i_CLKIN1=clk32b, i_CLKIN2=0, i_CLKINSEL=1,
+                                     p_CLKIN1_PERIOD=1000000000/f0, p_CLKIN2_PERIOD=0.,
+                                     i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
+                                     o_CLKOUT0=pll[0], p_CLKOUT0_DUTY_CYCLE=.5,
+                                     o_CLKOUT1=pll[1], p_CLKOUT1_DUTY_CYCLE=.5,
+                                     o_CLKOUT2=pll[2], p_CLKOUT2_DUTY_CYCLE=.5,
+                                     o_CLKOUT3=pll[3], p_CLKOUT3_DUTY_CYCLE=.5,
+                                     o_CLKOUT4=pll[4], p_CLKOUT4_DUTY_CYCLE=.5,
+                                     o_CLKOUT5=pll[5], p_CLKOUT5_DUTY_CYCLE=.5,
+                                     p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//1,
+                                     p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=p//1,
+                                     p_CLKOUT2_PHASE=0., p_CLKOUT2_DIVIDE=p//1,
+                                     p_CLKOUT3_PHASE=0., p_CLKOUT3_DIVIDE=p//1,
+                                     p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=p//1,  # sys
+                                     p_CLKOUT5_PHASE=270., p_CLKOUT5_DIVIDE=p//1,  # sys_ps
+        )
+        self.specials += Instance("BUFG", i_I=pll[4], o_O=self.cd_sys.clk)
+        self.specials += Instance("BUFG", i_I=pll[5], o_O=self.cd_sys_ps.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd)
+
+        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
+                                  p_INIT=0, p_SRTYPE="SYNC",
+                                  i_D0=0, i_D1=1, i_S=0, i_R=0, i_CE=1,
+                                  i_C0=self.cd_sys.clk, i_C1=~self.cd_sys.clk,
+                                  o_Q=platform.request("sdram_clock"))

--- a/targets/neso/base.py
+++ b/targets/neso/base.py
@@ -89,10 +89,8 @@ class BaseSoC(SoCSDRAM):
     }}
 
     def __init__(self, platform, spiflash="spiflash_1x", **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0x8000
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x8000
+        kwargs['integrated_rom_size']=0x8000
+        kwargs['integrated_sram_size']=0x8000
 
         clk_freq = int(100e6)
         SoCSDRAM.__init__(self, platform, clk_freq, **kwargs)

--- a/targets/neso/base.py
+++ b/targets/neso/base.py
@@ -13,7 +13,7 @@ from litedram.core import ControllerSettings
 from gateware import info
 from gateware import spi_flash
 
-from targets.utils import csr_map_update, period_ns
+from targets.utils import period_ns
 
 
 class _CRG(Module):
@@ -84,17 +84,9 @@ class _CRG(Module):
 
 
 class BaseSoC(SoCSDRAM):
-    csr_peripherals = (
-        "spiflash",
-        "ddrphy",
-        "info",
-    )
-    csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
-
-    mem_map = {
-        "spiflash": 0x20000000,  # (default shadow @0xa0000000)
-    }
-    mem_map.update(SoCSDRAM.mem_map)
+    mem_map = {**SoCSDRAM.mem_map, **{
+        "spiflash": 0x20000000,
+    }}
 
     def __init__(self, platform, spiflash="spiflash_1x", **kwargs):
         if 'integrated_rom_size' not in kwargs:
@@ -111,6 +103,7 @@ class BaseSoC(SoCSDRAM):
 
         # Basic peripherals
         self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.add_csr("info")
 
         # spi flash
         spiflash_pads = platform.request(spiflash)
@@ -126,6 +119,7 @@ class BaseSoC(SoCSDRAM):
                 spiflash_pads,
                 dummy=spiflash_dummy[spiflash],
                 div=2)
+        self.add_csr("spiflash")
         self.add_constant("SPIFLASH_PAGE_SIZE", 256)
         self.add_constant("SPIFLASH_SECTOR_SIZE", 0x10000)
         self.add_wb_slave(mem_decoder(self.mem_map["spiflash"]), self.spiflash.bus)
@@ -137,6 +131,7 @@ class BaseSoC(SoCSDRAM):
         sdram_module = MT41K128M16(self.clk_freq, "1:4")
         self.submodules.ddrphy = a7ddrphy.A7DDRPHY(
             platform.request("ddram"))
+        self.add_csr("ddrphy")
         self.add_constant("READ_LEVELING_BITSLIP", 3)
         self.add_constant("READ_LEVELING_DELAY", 14)
         controller_settings = ControllerSettings(

--- a/targets/netv2/base.py
+++ b/targets/netv2/base.py
@@ -14,7 +14,7 @@ from litedram.core import ControllerSettings
 from gateware import cas
 from gateware import info
 
-from targets.utils import csr_map_update, period_ns
+from targets.utils import period_ns
 
 
 class _CRG(Module):
@@ -93,25 +93,14 @@ class _CRG(Module):
 
 
 class BaseSoC(SoCSDRAM):
-    csr_peripherals = (
-        "ddrphy",
-        "info",
-        "cas",
-    )
-    csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
-
-    SoCSDRAM.mem_map = {
-        "rom":      0x00000000,
-        "sram":     0x10000000,
-        "main_ram": 0x40000000,
-        "csr":      0xe0000000,
-    }
-
-    mem_map = {
-        "spiflash": 0x20000000,
+    mem_map = {**SoCSDRAM.mem_map, **{
+        "rom":          0x00000000,
+        "sram":         0x10000000,
+        "main_ram":     0x40000000,
+        "csr":          0xe0000000,
+        "spiflash":     0x20000000,
         "emulator_ram": 0x50000000,
-    }
-    mem_map.update(SoCSDRAM.mem_map)
+    }}
 
     def __init__(self, platform, csr_data_width=8, **kwargs):
         if 'integrated_rom_size' not in kwargs:
@@ -128,7 +117,9 @@ class BaseSoC(SoCSDRAM):
 
         # Basic peripherals
         self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.add_csr("info")
         self.submodules.cas = cas.ControlAndStatus(platform, clk_freq)
+        self.add_csr("cas")
 
         if self.cpu_type == "vexriscv" and self.cpu_variant == "linux":
             size = 0x4000
@@ -141,6 +132,7 @@ class BaseSoC(SoCSDRAM):
         sdram_module = K4B2G1646F(self.clk_freq, "1:4")
         self.submodules.ddrphy = a7ddrphy.A7DDRPHY(
             platform.request("ddram"))
+        self.add_csr("ddrphy")
         controller_settings = ControllerSettings(
             with_bandwidth=True,
             cmd_buffer_depth=8,

--- a/targets/netv2/base.py
+++ b/targets/netv2/base.py
@@ -103,10 +103,8 @@ class BaseSoC(SoCSDRAM):
     }}
 
     def __init__(self, platform, csr_data_width=8, **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0x8000
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x8000
+        kwargs['integrated_rom_size']=0x8000
+        kwargs['integrated_sram_size']=0x8000
 
         clk_freq = int(100e6)
         SoCSDRAM.__init__(self, platform, clk_freq, csr_data_width=csr_data_width, **kwargs)

--- a/targets/nexys_video/base.py
+++ b/targets/nexys_video/base.py
@@ -1,162 +1,124 @@
 # Support for Digilent Nexys Video board
 from migen import *
-from migen.genlib.resetsync import AsyncResetSynchronizer
 
-from litex.soc.integration.soc_core import mem_decoder
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
-from litex.soc.cores.uart import *
 
 from litedram.modules import MT41K256M16
-from litedram.phy import a7ddrphy
+from litedram.phy import s6ddrphy
 from litedram.core import ControllerSettings
 
+from gateware import cas
 from gateware import info
 from gateware import oled
 from gateware import spi_flash
 
-from targets.utils import csr_map_update, period_ns
-
-
-class _CRG(Module):
-    def __init__(self, platform):
-        self.clock_domains.cd_sys = ClockDomain()
-        self.clock_domains.cd_sys4x = ClockDomain(reset_less=True)
-        self.clock_domains.cd_sys4x_dqs = ClockDomain(reset_less=True)
-        self.clock_domains.cd_clk200 = ClockDomain()
-        self.clock_domains.cd_clk100 = ClockDomain()
-
-        clk100 = platform.request("clk100")
-        rst = ~platform.request("cpu_reset")
-
-        pll_locked = Signal()
-        pll_fb = Signal()
-        self.pll_sys = Signal()
-        pll_sys4x = Signal()
-        pll_sys4x_dqs = Signal()
-        pll_clk200 = Signal()
-        self.specials += [
-            Instance("PLLE2_BASE",
-                     p_STARTUP_WAIT="FALSE", o_LOCKED=pll_locked,
-
-                     # VCO @ 1600 MHz
-                     p_REF_JITTER1=0.01, p_CLKIN1_PERIOD=10.0,
-                     p_CLKFBOUT_MULT=16, p_DIVCLK_DIVIDE=1,
-                     i_CLKIN1=clk100, i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb,
-
-                     # 100 MHz
-                     p_CLKOUT0_DIVIDE=16, p_CLKOUT0_PHASE=0.0,
-                     o_CLKOUT0=self.pll_sys,
-
-                     # 400 MHz
-                     p_CLKOUT1_DIVIDE=4, p_CLKOUT1_PHASE=0.0,
-                     o_CLKOUT1=pll_sys4x,
-
-                     # 400 MHz dqs
-                     p_CLKOUT2_DIVIDE=4, p_CLKOUT2_PHASE=90.0,
-                     o_CLKOUT2=pll_sys4x_dqs,
-
-                     # 200 MHz
-                     p_CLKOUT3_DIVIDE=8, p_CLKOUT3_PHASE=0.0,
-                     o_CLKOUT3=pll_clk200
-            ),
-            Instance("BUFG", i_I=self.pll_sys, o_O=self.cd_sys.clk),
-            Instance("BUFG", i_I=pll_sys4x, o_O=self.cd_sys4x.clk),
-            Instance("BUFG", i_I=pll_sys4x_dqs, o_O=self.cd_sys4x_dqs.clk),
-            Instance("BUFG", i_I=pll_clk200, o_O=self.cd_clk200.clk),
-            Instance("BUFG", i_I=clk100, o_O=self.cd_clk100.clk),
-            AsyncResetSynchronizer(self.cd_sys, ~pll_locked | rst),
-            AsyncResetSynchronizer(self.cd_clk200, ~pll_locked | rst),
-            AsyncResetSynchronizer(self.cd_clk100, ~pll_locked | rst),
-        ]
-
-        reset_counter = Signal(4, reset=15)
-        ic_reset = Signal(reset=1)
-        self.sync.clk200 += \
-            If(reset_counter != 0,
-                reset_counter.eq(reset_counter - 1)
-            ).Else(
-                ic_reset.eq(0)
-            )
-        self.specials += Instance("IDELAYCTRL", i_REFCLK=ClockSignal("clk200"), i_RST=ic_reset)
+from .crg import _CRG
 
 
 class BaseSoC(SoCSDRAM):
-    csr_peripherals = (
-        "spiflash",
-        "ddrphy",
-        "info",
-        "oled",
-        "uart",
-        "uart_phy",
-    )
-    csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
+    mem_map = {**SoCSDRAM.mem_map, **{
+        'spiflash': 0x20000000,
+    }}
 
-    mem_map = {
-        "spiflash": 0x20000000,  # (default shadow @0xa0000000)
-    }
-    mem_map.update(SoCSDRAM.mem_map)
+    #    "oled",
+    #    "uart",
+    #    "uart_phy",
 
     def __init__(self, platform, spiflash="spiflash_1x", **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0x8000
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x8000
+        kwargs['integrated_rom_size']=0x8000
+        kwargs['integrated_sram_size']=0x8000
 
-        clk_freq = int(100e6)
-        SoCSDRAM.__init__(self, platform, clk_freq, with_uart=False, **kwargs)
+        sys_clk_freq = int(100e6)
+        # SoCSDRAM ---------------------------------------------------------------------------------
+        SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq, with_uart=False, **kwargs)
 
+        # CRG --------------------------------------------------------------------------------------
         self.submodules.crg = _CRG(platform)
         self.crg.cd_sys.clk.attr.add("keep")
-        self.platform.add_period_constraint(self.crg.cd_sys.clk, period_ns(clk_freq))
+        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/sys_clk_freq)
 
+        # DDR3 SDRAM -------------------------------------------------------------------------------
+        if True:
+            sdram_module = MT41K256M16(sys_clk_freq, "1:4")
+            self.submodules.ddrphy = s7ddrphy.A7DDRPHY(
+                platform.request("ddram"),
+                memtype      = sdram_module.memtype,
+                nphases      = 4,
+                sys_clk_freq = sys_clk_freq)
+            self.add_csr("ddrphy")
+            self.add_constant("READ_LEVELING_BITSLIP", 3)
+            self.add_constant("READ_LEVELING_DELAY", 14)
+            self.register_sdram(
+                self.ddrphy,
+                geom_settings   = sdram_module.geom_settings,
+                timing_settings = sdram_module.timing_settings,
+                controller_settings=ControllerSettings(
+                    with_bandwidth=True,
+                    cmd_buffer_depth=8,
+                    with_refresh=True))
+
+        # Extended UART ----------------------------------------------------------------------------
         uart_interfaces = [RS232PHYInterface() for i in range(2)]
         self.submodules.uart = UART(uart_interfaces[0])
         self.submodules.bridge = WishboneStreamingBridge(uart_interfaces[1], self.clk_freq)
         self.add_wb_master(self.bridge.wishbone)
+        self.add_csr("uart")
+        self.add_interrupt("uart")
 
         self.submodules.uart_phy = RS232PHY(platform.request("serial"), self.clk_freq, 115200)
         self.submodules.uart_multiplexer = RS232PHYMultiplexer(uart_interfaces, self.uart_phy)
         self.comb += self.uart_multiplexer.sel.eq(platform.request("user_sw", 0))
+        self.add_csr("uart_phy")
 
-        # Basic peripherals
+        # Basic peripherals ------------------------------------------------------------------------
         self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.add_csr("info")
+        self.submodules.cas = cas.ControlAndStatus(platform, sys_clk_freq)
+        self.add_csr("cas")
         self.submodules.oled = oled.OLED(platform.request("oled"))
+        self.add_csr("oled")
 
-        # sdram
-        self.submodules.ddrphy = a7ddrphy.A7DDRPHY(platform.request("ddram"))
-        self.add_constant("READ_LEVELING_BITSLIP", 3)
-        self.add_constant("READ_LEVELING_DELAY", 14)
-        sdram_module = MT41K256M16(self.clk_freq, "1:4")
-        self.register_sdram(self.ddrphy,
-                            sdram_module.geom_settings,
-                            sdram_module.timing_settings,
-                            controller_settings=ControllerSettings(
-                                with_bandwidth=True,
-                                cmd_buffer_depth=8,
-                                with_refresh=True))
+        # Add debug interface if the CPU has one ---------------------------------------------------
+        if hasattr(self.cpu, "debug_bus"):
+            self.register_mem(
+                name="vexriscv_debug",
+                address=0xf00f0000,
+                interface=self.cpu.debug_bus,
+                size=0x100)
 
-        # spi flash
+        # Memory mapped SPI Flash ------------------------------------------------------------------
         spiflash_pads = platform.request(spiflash)
         spiflash_pads.clk = Signal()
-        self.specials += Instance("STARTUPE2",
-                                  i_CLK=0, i_GSR=0, i_GTS=0, i_KEYCLEARB=0, i_PACK=0,
-                                  i_USRCCLKO=spiflash_pads.clk, i_USRCCLKTS=0, i_USRDONEO=1, i_USRDONETS=1)
+        self.specials += Instance(
+            "STARTUPE2",
+            i_CLK=0, i_GSR=0, i_GTS=0, i_KEYCLEARB=0, i_PACK=0,
+            i_USRCCLKO=spiflash_pads.clk, i_USRCCLKTS=0, i_USRDONEO=1, i_USRDONETS=1)
         spiflash_dummy = {
             "spiflash_1x": 9,
             "spiflash_4x": 11,
         }
         self.submodules.spiflash = spi_flash.SpiFlash(
-                spiflash_pads,
-                dummy=spiflash_dummy[spiflash],
-                div=2)
-        self.add_constant("SPIFLASH_PAGE_SIZE", 256)
-        self.add_constant("SPIFLASH_SECTOR_SIZE", 0x10000)
-        self.add_wb_slave(mem_decoder(self.mem_map["spiflash"]), self.spiflash.bus)
+            spiflash_pads,
+            dummy=spiflash_dummy[spiflash],
+            div=platform.spiflash_clock_div,
+            endianness=self.cpu.endianness)
+        self.add_csr("spiflash")
+        self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
+        self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
+        self.add_constant("SPIFLASH_TOTAL_SIZE", platform.spiflash_total_size)
+        self.add_wb_slave(
+            self.mem_map["spiflash"],
+            self.spiflash.bus,
+            platform.spiflash_total_size)
         self.add_memory_region(
-            "spiflash", self.mem_map["spiflash"], 16*1024*1024)
+            "spiflash",
+            self.mem_map["spiflash"],
+            platform.spiflash_total_size)
 
-        self.add_interrupt("uart")
+        bios_size = 0x8000
+        self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
 
 
 SoC = BaseSoC

--- a/targets/nexys_video/base.py
+++ b/targets/nexys_video/base.py
@@ -1,11 +1,13 @@
 # Support for Digilent Nexys Video board
 from migen import *
 
+from litex.soc.cores.uart import * #UART, RS232PHYInterface, RS232PHY, RS232PHYMultiplexer
+from litex.soc.interconnect.wishbonebridge import WishboneStreamingBridge
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
 
 from litedram.modules import MT41K256M16
-from litedram.phy import s6ddrphy
+from litedram.phy import s7ddrphy
 from litedram.core import ControllerSettings
 
 from gateware import cas
@@ -34,7 +36,7 @@ class BaseSoC(SoCSDRAM):
         SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq, with_uart=False, **kwargs)
 
         # CRG --------------------------------------------------------------------------------------
-        self.submodules.crg = _CRG(platform)
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
         self.crg.cd_sys.clk.attr.add("keep")
         self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/sys_clk_freq)
 
@@ -61,7 +63,7 @@ class BaseSoC(SoCSDRAM):
         # Extended UART ----------------------------------------------------------------------------
         uart_interfaces = [RS232PHYInterface() for i in range(2)]
         self.submodules.uart = UART(uart_interfaces[0])
-        self.submodules.bridge = WishboneStreamingBridge(uart_interfaces[1], self.clk_freq)
+        self.submodules.bridge = WishboneStreamingBridge(uart_interfaces[1], sys_clk_freq)
         self.add_wb_master(self.bridge.wishbone)
         self.add_csr("uart")
         self.add_interrupt("uart")

--- a/targets/nexys_video/crg.py
+++ b/targets/nexys_video/crg.py
@@ -1,0 +1,67 @@
+# Support for Digilent Nexys Video board
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq):
+        self.clock_domains.cd_sys = ClockDomain()
+        self.clock_domains.cd_sys4x = ClockDomain(reset_less=True)
+        self.clock_domains.cd_sys4x_dqs = ClockDomain(reset_less=True)
+        self.clock_domains.cd_clk200 = ClockDomain()
+        self.clock_domains.cd_clk100 = ClockDomain()
+
+        clk100 = platform.request("clk100")
+        rst = ~platform.request("cpu_reset")
+
+        pll_locked = Signal()
+        pll_fb = Signal()
+        self.pll_sys = Signal()
+        pll_sys4x = Signal()
+        pll_sys4x_dqs = Signal()
+        pll_clk200 = Signal()
+        self.specials += [
+            Instance("PLLE2_BASE",
+                     p_STARTUP_WAIT="FALSE", o_LOCKED=pll_locked,
+
+                     # VCO @ 1600 MHz
+                     p_REF_JITTER1=0.01, p_CLKIN1_PERIOD=10.0,
+                     p_CLKFBOUT_MULT=16, p_DIVCLK_DIVIDE=1,
+                     i_CLKIN1=clk100, i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb,
+
+                     # 100 MHz
+                     p_CLKOUT0_DIVIDE=16, p_CLKOUT0_PHASE=0.0,
+                     o_CLKOUT0=self.pll_sys,
+
+                     # 400 MHz
+                     p_CLKOUT1_DIVIDE=4, p_CLKOUT1_PHASE=0.0,
+                     o_CLKOUT1=pll_sys4x,
+
+                     # 400 MHz dqs
+                     p_CLKOUT2_DIVIDE=4, p_CLKOUT2_PHASE=90.0,
+                     o_CLKOUT2=pll_sys4x_dqs,
+
+                     # 200 MHz
+                     p_CLKOUT3_DIVIDE=8, p_CLKOUT3_PHASE=0.0,
+                     o_CLKOUT3=pll_clk200
+            ),
+            Instance("BUFG", i_I=self.pll_sys, o_O=self.cd_sys.clk),
+            Instance("BUFG", i_I=pll_sys4x, o_O=self.cd_sys4x.clk),
+            Instance("BUFG", i_I=pll_sys4x_dqs, o_O=self.cd_sys4x_dqs.clk),
+            Instance("BUFG", i_I=pll_clk200, o_O=self.cd_clk200.clk),
+            Instance("BUFG", i_I=clk100, o_O=self.cd_clk100.clk),
+            AsyncResetSynchronizer(self.cd_sys, ~pll_locked | rst),
+            AsyncResetSynchronizer(self.cd_clk200, ~pll_locked | rst),
+            AsyncResetSynchronizer(self.cd_clk100, ~pll_locked | rst),
+        ]
+
+        reset_counter = Signal(4, reset=15)
+        ic_reset = Signal(reset=1)
+        self.sync.clk200 += \
+            If(reset_counter != 0,
+                reset_counter.eq(reset_counter - 1)
+            ).Else(
+                ic_reset.eq(0)
+            )
+        self.specials += Instance("IDELAYCTRL", i_REFCLK=ClockSignal("clk200"), i_RST=ic_reset)

--- a/targets/nexys_video/net.py
+++ b/targets/nexys_video/net.py
@@ -9,16 +9,10 @@ from targets.nexys_video.base import SoC as BaseSoC
 
 
 class NetSoC(BaseSoC):
-    csr_peripherals = (
-        "ethphy",
-        "ethmac",
+    mem_map = dict(
+        **BaseSoC.mem_map,
+        ethmac=0xb0000000,
     )
-    csr_map_update(BaseSoC.csr_map, csr_peripherals)
-
-    mem_map = {
-        "ethmac": 0x30000000,  # (shadow @0xb0000000)
-    }
-    mem_map.update(BaseSoC.mem_map)
 
     def __init__(self, platform, *args, **kwargs):
         # Need a larger integrated ROM on or1k to fit the BIOS with TFTP support.
@@ -27,14 +21,20 @@ class NetSoC(BaseSoC):
 
         BaseSoC.__init__(self, platform, *args, **kwargs)
 
-        self.submodules.ethphy = LiteEthPHYRGMII(
+        # Ethernet PHY
+	self.submodules.ethphy = LiteEthPHYRGMII(
             platform.request("eth_clocks"),
             platform.request("eth"))
+        self.add_csr("ethphy")
+
+        # Ethernet MAC
+        ethmac_win_size = 0x2000
         self.submodules.ethmac = LiteEthMAC(
             phy=self.ethphy, dw=32, interface="wishbone", endianness=self.cpu.endianness)
-        self.add_wb_slave(mem_decoder(self.mem_map["ethmac"]), self.ethmac.bus)
-        self.add_memory_region("ethmac",
-            self.mem_map["ethmac"] | self.shadow_base, 0x2000)
+        self.add_wb_slave(self.mem_map["ethmac"], self.ethmac.bus, ethmac_win_size)
+        self.add_memory_region("ethmac", self.mem_map["ethmac"], ethmac_win_size, type="io")
+        self.add_csr("ethmac")
+        self.add_interrupt("ethmac")
 
         self.ethphy.crg.cd_eth_rx.clk.attr.add("keep")
         self.ethphy.crg.cd_eth_tx.clk.attr.add("keep")

--- a/targets/nexys_video/net.py
+++ b/targets/nexys_video/net.py
@@ -45,8 +45,6 @@ class NetSoC(BaseSoC):
             self.ethphy.crg.cd_eth_rx.clk,
             self.ethphy.crg.cd_eth_tx.clk)
 
-        self.add_interrupt("ethmac")
-
     def configure_iprange(self, iprange):
         iprange = [int(x) for x in iprange.split(".")]
         while len(iprange) < 4:

--- a/targets/nexys_video/net.py
+++ b/targets/nexys_video/net.py
@@ -4,7 +4,6 @@ from litex.soc.integration.soc_sdram import *
 from liteeth.core.mac import LiteEthMAC
 from liteeth.phy.s7rgmii import LiteEthPHYRGMII
 
-from targets.utils import csr_map_update
 from targets.nexys_video.base import SoC as BaseSoC
 
 
@@ -22,7 +21,7 @@ class NetSoC(BaseSoC):
         BaseSoC.__init__(self, platform, *args, **kwargs)
 
         # Ethernet PHY
-	self.submodules.ethphy = LiteEthPHYRGMII(
+        self.submodules.ethphy = LiteEthPHYRGMII(
             platform.request("eth_clocks"),
             platform.request("eth"))
         self.add_csr("ethphy")

--- a/targets/nexys_video/video.py
+++ b/targets/nexys_video/video.py
@@ -5,19 +5,11 @@ from litex.soc.cores.freqmeter import FreqMeter
 
 from litescope import LiteScopeAnalyzer
 
-from targets.utils import csr_map_update, period_ns
+from targets.utils import period_ns
 from targets.nexys_video.net import NetSoC as BaseSoC
 
 
 class VideoSoC(BaseSoC):
-    csr_peripherals = (
-        "hdmi_out0",
-        "hdmi_in0",
-        "hdmi_in0_freq",
-        "hdmi_in0_edid_mem",
-    )
-    csr_map_update(BaseSoC.csr_map, csr_peripherals)
-
     def __init__(self, platform, *args, **kwargs):
         BaseSoC.__init__(self, platform, *args, **kwargs)
 
@@ -40,8 +32,12 @@ class VideoSoC(BaseSoC):
             fifo_depth=512,
             device="xc7",
         )
+        self.add_csr("hdmi_in0")
+        self.add_csr("hdmi_in0_edid_mem")
+        self.add_interrupt("hdmi_in0")
 
         self.submodules.hdmi_in0_freq = FreqMeter(period=self.clk_freq)
+        self.add_csr("hdmi_in0_freq")
 
         self.comb += [
             self.hdmi_in0_freq.clk.eq(self.hdmi_in0.clocking.cd_pix.clk),
@@ -74,6 +70,7 @@ class VideoSoC(BaseSoC):
             mode=mode,
             fifo_depth=4096,
         )
+        self.add_csr("hdmi_out0")
 
         self.platform.add_false_path_constraints(
             self.crg.cd_sys.clk,
@@ -90,15 +87,8 @@ class VideoSoC(BaseSoC):
         for name, value in sorted(self.platform.hdmi_infos.items()):
             self.add_constant(name, value)
 
-        self.add_interrupt("hdmi_in0")
-
 
 class VideoSoCDebug(VideoSoC):
-    csr_peripherals = (
-        "analyzer",
-    )
-    csr_map_update(VideoSoC.csr_map, csr_peripherals)
-
     def __init__(self, platform, *args, **kwargs):
         VideoSoC.__init__(self, platform, *args, **kwargs)
 

--- a/targets/opsis/axiom.py
+++ b/targets/opsis/axiom.py
@@ -1,7 +1,6 @@
 from migen import *
 from litex.soc.cores.gpio import GPIOIn, GPIOOut
 
-from targets.utils import csr_map_update
 from targets.opsis.net import NetSoC as BaseSoC
 
 
@@ -22,15 +21,11 @@ class GPIO2TOFE(Module):
 
 
 class AxiomSoC(BaseSoC):
-    csr_peripherals = (
-        "gpio",
-    )
-    csr_map_update(BaseSoC.csr_map, csr_peripherals)
-
     def __init__(self, platform, *args, **kwargs):
         BaseSoC.__init__(self, platform, *args, expansion='tofe2axiom', **kwargs)
 
         self.submodules.gpio = GPIO2TOFE(platform.request("tofe", 0))
+        self.add_csr("gpio")
 
 
 SoC = AxiomSoC

--- a/targets/opsis/base.py
+++ b/targets/opsis/base.py
@@ -1,9 +1,5 @@
 # Support for Numato Opsis - https://opsis.hdmi2usb.tv
-from fractions import Fraction
-
 from migen import *
-from migen.genlib.resetsync import AsyncResetSynchronizer
-from migen.genlib.misc import WaitTimer
 
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
@@ -15,14 +11,13 @@ from litedram.modules import MT41J128M16
 from litedram.phy import s6ddrphy
 from litedram.core import ControllerSettings
 
+#from gateware import cas
 from gateware import i2c
 from gateware import info
 from gateware import opsis_i2c
 from gateware import shared_uart
 from gateware import tofe
 from gateware import spi_flash
-
-from targets.utils import csr_map_update
 
 
 class FrontPanelGPIO(Module, AutoCSR):
@@ -50,168 +45,10 @@ class FrontPanelGPIO(Module, AutoCSR):
         ]
 
 
-class _CRG(Module):
-    def __init__(self, platform, clk_freq):
-        # Clock domains for the system (soft CPU and related components run at).
-        self.clock_domains.cd_sys = ClockDomain()
-        self.clock_domains.cd_sys2x = ClockDomain()
-        # Clock domains for the DDR interface.
-        self.clock_domains.cd_sdram_half = ClockDomain()
-        self.clock_domains.cd_sdram_full_wr = ClockDomain()
-        self.clock_domains.cd_sdram_full_rd = ClockDomain()
-        # Clock domain for peripherals (such as HDMI output).
-        self.clock_domains.cd_base50 = ClockDomain()
-        self.clock_domains.cd_encoder = ClockDomain()
-
-        self.reset = Signal()
-
-        # Input 100MHz clock
-        f0 = 100*1000000
-        clk100 = platform.request("clk100")
-        clk100a = Signal()
-        # Input 100MHz clock (buffered)
-        self.specials += Instance("IBUFG", i_I=clk100, o_O=clk100a)
-        clk100b = Signal()
-        self.specials += Instance(
-            "BUFIO2", p_DIVIDE=1,
-            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
-            i_I=clk100a, o_DIVCLK=clk100b)
-
-        f = Fraction(int(clk_freq), int(f0))
-        n, m = f.denominator, f.numerator
-        assert f0/n*m == clk_freq
-        p = 8
-
-        # Unbuffered output signals from the PLL. They need to be buffered
-        # before feeding into the fabric.
-        unbuf_sdram_full = Signal()
-        unbuf_sdram_half_a = Signal()
-        unbuf_sdram_half_b = Signal()
-        unbuf_encoder = Signal()
-        unbuf_sys = Signal()
-        unbuf_sys2x = Signal()
-
-        # PLL signals
-        pll_lckd = Signal()
-        pll_fb = Signal()
-        self.specials.pll = Instance(
-            "PLL_ADV",
-            name="crg_pll_adv",
-            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
-            p_REF_JITTER=.01,
-            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
-            p_DIVCLK_DIVIDE=1,
-            # Input Clocks (100MHz)
-            i_CLKIN1=clk100b,
-            p_CLKIN1_PERIOD=1e9/f0,
-            i_CLKIN2=0,
-            p_CLKIN2_PERIOD=0.,
-            i_CLKINSEL=1,
-            # Feedback
-            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
-            p_CLK_FEEDBACK="CLKFBOUT",
-            p_CLKFBOUT_MULT=m*p//n, p_CLKFBOUT_PHASE=0.,
-            # (400MHz) ddr3 wr/rd full clock
-            o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
-            p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//8,
-            # ( 66MHz) encoder
-            o_CLKOUT1=unbuf_encoder, p_CLKOUT1_DUTY_CYCLE=.5,
-            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=6,
-            # (200MHz) sdram_half - ddr3 dqs adr ctrl off-chip
-            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
-            p_CLKOUT2_PHASE=230., p_CLKOUT2_DIVIDE=p//4,
-            # (200MHz) off-chip ddr - ddr3 half clock
-            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
-            p_CLKOUT3_PHASE=210., p_CLKOUT3_DIVIDE=p//4,
-            # (100MHz) sys2x - 2x system clock
-            o_CLKOUT4=unbuf_sys2x, p_CLKOUT4_DUTY_CYCLE=.5,
-            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=p//2,
-            # ( 50MHz) periph / sys - system clock
-            o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
-            p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=p//1,
-        )
-
-
-        # power on reset?
-        reset = ~platform.request("cpu_reset") | self.reset
-        self.clock_domains.cd_por = ClockDomain()
-        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
-        self.sync.por += If(por != 0, por.eq(por - 1))
-        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
-
-        # System clock - 50MHz
-        self.specials += Instance("BUFG", name="sys_bufg", i_I=unbuf_sys, o_O=self.cd_sys.clk)
-        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
-        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
-
-        # sys2x
-        self.specials += Instance("BUFG", name="sys2x_bufg", i_I=unbuf_sys2x, o_O=self.cd_sys2x.clk)
-        self.specials += AsyncResetSynchronizer(self.cd_sys2x, ~pll_lckd | (por > 0))
-
-        # SDRAM clocks
-        # ------------------------------------------------------------------------------
-        self.clk8x_wr_strb = Signal()
-        self.clk8x_rd_strb = Signal()
-
-        # sdram_full
-        self.specials += Instance("BUFPLL", name="sdram_full_bufpll",
-                                  p_DIVIDE=4,
-                                  i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys2x.clk,
-                                  i_LOCKED=pll_lckd,
-                                  o_IOCLK=self.cd_sdram_full_wr.clk,
-                                  o_SERDESSTROBE=self.clk8x_wr_strb)
-        self.comb += [
-            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
-            self.clk8x_rd_strb.eq(self.clk8x_wr_strb),
-        ]
-        # sdram_half
-        self.specials += Instance("BUFG", name="sdram_half_a_bufpll", i_I=unbuf_sdram_half_a, o_O=self.cd_sdram_half.clk)
-        clk_sdram_half_shifted = Signal()
-        self.specials += Instance("BUFG", name="sdram_half_b_bufpll", i_I=unbuf_sdram_half_b, o_O=clk_sdram_half_shifted)
-
-        output_clk = Signal()
-        clk = platform.request("ddram_clock")
-        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
-                                  p_INIT=0, p_SRTYPE="SYNC",
-                                  i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
-                                  i_C0=clk_sdram_half_shifted,
-                                  i_C1=~clk_sdram_half_shifted,
-                                  o_Q=output_clk)
-        self.specials += Instance("OBUFDS", i_I=output_clk, o_O=clk.p, o_OB=clk.n)
-
-        # Peripheral clock - 50MHz
-        # ------------------------------------------------------------------------------
-        # The peripheral clock is kept separate from the system clock to allow
-        # the system clock to be increased in the future.
-        dcm_base50_locked = Signal()
-        self.specials += [
-            Instance("DCM_CLKGEN", name="crg_periph_dcm_clkgen",
-                     p_CLKIN_PERIOD=10.0,
-                     p_CLKFX_MULTIPLY=2,
-                     p_CLKFX_DIVIDE=4,
-                     p_CLKFX_MD_MAX=0.5, # CLKFX_MULTIPLY/CLKFX_DIVIDE
-                     p_CLKFXDV_DIVIDE=2,
-                     p_SPREAD_SPECTRUM="NONE",
-                     p_STARTUP_WAIT="FALSE",
-
-                     i_CLKIN=clk100a,
-                     o_CLKFX=self.cd_base50.clk,
-                     o_LOCKED=dcm_base50_locked,
-                     i_FREEZEDCM=0,
-                     i_RST=ResetSignal(),
-                     ),
-            AsyncResetSynchronizer(self.cd_base50,
-                self.cd_sys.rst | ~dcm_base50_locked)
-        ]
-        platform.add_period_constraint(self.cd_base50.clk, 20)
-
-        # Encoder clock - 66 MHz
-        # ------------------------------------------------------------------------------
-        self.specials += Instance("BUFG", name="encoder_bufg", i_I=unbuf_encoder, o_O=self.cd_encoder.clk)
-        self.specials += AsyncResetSynchronizer(self.cd_encoder, self.cd_sys.rst)
-
-
 class BaseSoC(SoCSDRAM):
+    mem_map = {**SoCSDRAM.mem_map, **{
+        'spiflash': 0x20000000,
+    }}
     csr_peripherals = (
         "spiflash",
         "front_panel",
@@ -232,12 +69,10 @@ class BaseSoC(SoCSDRAM):
     mem_map.update(SoCSDRAM.mem_map)
 
     def __init__(self, platform, **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0x8000
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x8000
+        kwargs['integrated_rom_size']=0x8000
+        kwargs['integrated_sram_size']=0x8000
 
-        clk_freq = 50*1000000
+        sys_clk_freq = 50*1000000
 
         if 'expansion' in kwargs:
             tofe_board_name = kwargs.get('expansion')
@@ -245,65 +80,97 @@ class BaseSoC(SoCSDRAM):
         else:
             tofe_board_name = None
 
-        SoCSDRAM.__init__(self, platform, clk_freq, with_uart=False, **kwargs)
+        # SoCSDRAM ---------------------------------------------------------------------------------
+        SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq, with_uart=False, **kwargs)
 
-        self.submodules.crg = _CRG(platform, clk_freq)
-        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/clk_freq)
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/sys_clk_freq)
 
-        self.submodules.info = info.Info(platform, self.__class__.__name__)
-
-        self.submodules.opsis_i2c = opsis_i2c.OpsisI2C(platform)
-
+        # Add specialized uart ---------------------------------------------------------------------
         self.submodules.suart = shared_uart.SharedUART(self.clk_freq, 115200)
         self.suart.add_uart_pads(platform.request('fx2_serial'))
         self.submodules.uart = self.suart.uart
 
-        self.submodules.spiflash = spi_flash.SpiFlash(
-            platform.request("spiflash4x"),
-            dummy=platform.spiflash_read_dummy_bits,
-            div=platform.spiflash_clock_div)
-        self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
-        self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
-        self.register_mem("spiflash", self.mem_map["spiflash"],
-            self.spiflash.bus, size=platform.spiflash_total_size)
+        # DDR3 SDRAM -------------------------------------------------------------------------------
+        if True:
+            sdram_module = MT41J128M16(sys_clk_freq, "1:4")
+            self.submodules.ddrphy = s6ddrphy.S6QuarterRateDDRPHY(
+                platform.request("ddram"),
+                memtype      = sdram_module.memtype,
+                rd_bitslip   = 0,
+                wr_bitslip   = 4,
+                dqs_ddr_alignment="C0")
+            self.add_csr("ddrphy")
+            controller_settings = ControllerSettings(
+                with_bandwidth=True)
+            self.register_sdram(
+                self.ddrphy,
+                geom_settings   = sdram_module.geom_settings,
+                timing_settings = sdram_module.timing_settings,
+                controller_settings=controller_settings)
+            self.comb += [
+                self.ddrphy.clk8x_wr_strb.eq(self.crg.clk8x_wr_strb),
+                self.ddrphy.clk8x_rd_strb.eq(self.crg.clk8x_rd_strb),
+            ]
 
-        if self.cpu_type == "vexriscv" and self.cpu_variant == "linux":
-            size = 0x4000
-            self.submodules.emulator_ram = wishbone.SRAM(size)
-            self.register_mem("emulator_ram", self.mem_map["emulator_ram"], self.emulator_ram.bus, size)
-
-        bios_size = 0x8000
-        self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
-        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
-
-        # front panel (ATX)
+        # Basic peripherals ------------------------------------------------------------------------
+        # info module
+        self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.add_csr("info")
+        # control and status module
+        #self.submodules.cas = cas.ControlAndStatus(platform, sys_clk_freq)
+        self.add_csr("cas")
+        # opsis specific i2c module
+        self.submodules.opsis_i2c = opsis_i2c.OpsisI2C(platform)
+        self.add_csr("opsis_i2c")
+        # front panel (ATX) module
         self.submodules.front_panel = FrontPanelGPIO(platform, clk_freq)
         self.comb += self.crg.reset.eq(self.front_panel.reset)
 
-        # sdram
-        sdram_module = MT41J128M16(self.clk_freq, "1:4")
-        self.submodules.ddrphy = s6ddrphy.S6QuarterRateDDRPHY(
-            platform.request("ddram"),
-            rd_bitslip=0,
-            wr_bitslip=4,
-            dqs_ddr_alignment="C0")
-        controller_settings = ControllerSettings(with_bandwidth=True)
-        self.register_sdram(self.ddrphy,
-                            sdram_module.geom_settings,
-                            sdram_module.timing_settings,
-                            controller_settings=controller_settings)
-        self.comb += [
-            self.ddrphy.clk8x_wr_strb.eq(self.crg.clk8x_wr_strb),
-            self.ddrphy.clk8x_rd_strb.eq(self.crg.clk8x_rd_strb),
-        ]
-
+        # Expansion boards -------------------------------------------------------------------------
         if tofe_board_name:
             if tofe_board_name == 'lowspeedio':
                 self.submodules.tofe = tofe.TOFEBoard(tofe_board_name)(platform, self.suart)
             else:
                 self.submodules.tofe = tofe.TOFEBoard(tofe_board_name)(platform)
 
-        self.add_interrupt("uart")
+        # Add debug interface if the CPU has one ---------------------------------------------------
+        if hasattr(self.cpu, "debug_bus"):
+            self.register_mem(
+                name="vexriscv_debug",
+                address=0xf00f0000,
+                interface=self.cpu.debug_bus,
+                size=0x100)
+
+        # Memory mapped SPI Flash ------------------------------------------------------------------
+        self.submodules.spiflash = spi_flash.SpiFlash(
+            platform.request("spiflash4x"),
+            dummy=platform.spiflash_read_dummy_bits,
+            div=platform.spiflash_clock_div,
+            endianness=self.cpu.endianness)
+        self.add_csr("spiflash")
+        self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
+        self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
+        self.add_constant("SPIFLASH_TOTAL_SIZE", platform.spiflash_total_size)
+        self.add_wb_slave(
+            self.mem_map["spiflash"],
+            self.spiflash.bus,
+            platform.spiflash_total_size)
+        self.add_memory_region(
+            "spiflash",
+            self.mem_map["spiflash"],
+            platform.spiflash_total_size)
+
+        bios_size = 0x8000
+        self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
+
+        # Support for soft-emulation for full Linux support ----------------------------------------
+        if self.cpu_type == "vexriscv" and self.cpu_variant == "linux":
+            size = 0x4000
+            self.submodules.emulator_ram = wishbone.SRAM(size)
+            self.register_mem("emulator_ram", self.mem_map["emulator_ram"], self.emulator_ram.bus, size)
 
 
 SoC = BaseSoC

--- a/targets/opsis/base.py
+++ b/targets/opsis/base.py
@@ -48,25 +48,8 @@ class FrontPanelGPIO(Module, AutoCSR):
 class BaseSoC(SoCSDRAM):
     mem_map = {**SoCSDRAM.mem_map, **{
         'spiflash': 0x20000000,
+        "emulator_ram": 0x50000000,
     }}
-    csr_peripherals = (
-        "spiflash",
-        "front_panel",
-        "ddrphy",
-        "info",
-        "fx2_reset",
-        "fx2_hack",
-        "tofe",
-        "opsis_i2c",
-        "uart",
-    )
-    csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
-
-    mem_map = {
-        "spiflash":     0x20000000,  # (default shadow @0xa0000000)
-        "emulator_ram": 0x50000000,  # (default shadow @0xd0000000)
-    }
-    mem_map.update(SoCSDRAM.mem_map)
 
     def __init__(self, platform, **kwargs):
         kwargs['integrated_rom_size']=0x8000
@@ -91,6 +74,7 @@ class BaseSoC(SoCSDRAM):
         self.submodules.suart = shared_uart.SharedUART(self.clk_freq, 115200)
         self.suart.add_uart_pads(platform.request('fx2_serial'))
         self.submodules.uart = self.suart.uart
+        self.add_csr("uart")
 
         # DDR3 SDRAM -------------------------------------------------------------------------------
         if True:

--- a/targets/opsis/crg.py
+++ b/targets/opsis/crg.py
@@ -1,0 +1,168 @@
+# Support for Numato Opsis - https://opsis.hdmi2usb.tv
+
+from fractions import Fraction
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+from migen.genlib.misc import WaitTimer
+
+
+class _CRG(Module):
+    def __init__(self, platform, clk_freq):
+        # Clock domains for the system (soft CPU and related components run at).
+        self.clock_domains.cd_sys = ClockDomain()
+        self.clock_domains.cd_sys2x = ClockDomain()
+        # Clock domains for the DDR interface.
+        self.clock_domains.cd_sdram_half = ClockDomain()
+        self.clock_domains.cd_sdram_full_wr = ClockDomain()
+        self.clock_domains.cd_sdram_full_rd = ClockDomain()
+        # Clock domain for peripherals (such as HDMI output).
+        self.clock_domains.cd_base50 = ClockDomain()
+        self.clock_domains.cd_encoder = ClockDomain()
+
+        self.reset = Signal()
+
+        # Input 100MHz clock
+        f0 = 100*1000000
+        clk100 = platform.request("clk100")
+        clk100a = Signal()
+        # Input 100MHz clock (buffered)
+        self.specials += Instance("IBUFG", i_I=clk100, o_O=clk100a)
+        clk100b = Signal()
+        self.specials += Instance(
+            "BUFIO2", p_DIVIDE=1,
+            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
+            i_I=clk100a, o_DIVCLK=clk100b)
+
+        f = Fraction(int(clk_freq), int(f0))
+        n, m = f.denominator, f.numerator
+        assert f0/n*m == clk_freq
+        p = 8
+
+        # Unbuffered output signals from the PLL. They need to be buffered
+        # before feeding into the fabric.
+        unbuf_sdram_full = Signal()
+        unbuf_sdram_half_a = Signal()
+        unbuf_sdram_half_b = Signal()
+        unbuf_encoder = Signal()
+        unbuf_sys = Signal()
+        unbuf_sys2x = Signal()
+
+        # PLL signals
+        pll_lckd = Signal()
+        pll_fb = Signal()
+        self.specials.pll = Instance(
+            "PLL_ADV",
+            name="crg_pll_adv",
+            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
+            p_REF_JITTER=.01,
+            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
+            p_DIVCLK_DIVIDE=1,
+            # Input Clocks (100MHz)
+            i_CLKIN1=clk100b,
+            p_CLKIN1_PERIOD=1e9/f0,
+            i_CLKIN2=0,
+            p_CLKIN2_PERIOD=0.,
+            i_CLKINSEL=1,
+            # Feedback
+            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
+            p_CLK_FEEDBACK="CLKFBOUT",
+            p_CLKFBOUT_MULT=m*p//n, p_CLKFBOUT_PHASE=0.,
+            # (400MHz) ddr3 wr/rd full clock
+            o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
+            p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//8,
+            # ( 66MHz) encoder
+            o_CLKOUT1=unbuf_encoder, p_CLKOUT1_DUTY_CYCLE=.5,
+            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=6,
+            # (200MHz) sdram_half - ddr3 dqs adr ctrl off-chip
+            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
+            p_CLKOUT2_PHASE=230., p_CLKOUT2_DIVIDE=p//4,
+            # (200MHz) off-chip ddr - ddr3 half clock
+            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
+            p_CLKOUT3_PHASE=210., p_CLKOUT3_DIVIDE=p//4,
+            # (100MHz) sys2x - 2x system clock
+            o_CLKOUT4=unbuf_sys2x, p_CLKOUT4_DUTY_CYCLE=.5,
+            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=p//2,
+            # ( 50MHz) periph / sys - system clock
+            o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
+            p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=p//1,
+        )
+
+
+        # power on reset?
+        reset = ~platform.request("cpu_reset") | self.reset
+        self.clock_domains.cd_por = ClockDomain()
+        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
+        self.sync.por += If(por != 0, por.eq(por - 1))
+        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
+
+        # System clock - 50MHz
+        self.specials += Instance("BUFG", name="sys_bufg", i_I=unbuf_sys, o_O=self.cd_sys.clk)
+        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
+
+        # sys2x
+        self.specials += Instance("BUFG", name="sys2x_bufg", i_I=unbuf_sys2x, o_O=self.cd_sys2x.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_sys2x, ~pll_lckd | (por > 0))
+
+        # SDRAM clocks
+        # ------------------------------------------------------------------------------
+        self.clk8x_wr_strb = Signal()
+        self.clk8x_rd_strb = Signal()
+
+        # sdram_full
+        self.specials += Instance("BUFPLL", name="sdram_full_bufpll",
+                                  p_DIVIDE=4,
+                                  i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys2x.clk,
+                                  i_LOCKED=pll_lckd,
+                                  o_IOCLK=self.cd_sdram_full_wr.clk,
+                                  o_SERDESSTROBE=self.clk8x_wr_strb)
+        self.comb += [
+            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
+            self.clk8x_rd_strb.eq(self.clk8x_wr_strb),
+        ]
+        # sdram_half
+        self.specials += Instance("BUFG", name="sdram_half_a_bufpll", i_I=unbuf_sdram_half_a, o_O=self.cd_sdram_half.clk)
+        clk_sdram_half_shifted = Signal()
+        self.specials += Instance("BUFG", name="sdram_half_b_bufpll", i_I=unbuf_sdram_half_b, o_O=clk_sdram_half_shifted)
+
+        output_clk = Signal()
+        clk = platform.request("ddram_clock")
+        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
+                                  p_INIT=0, p_SRTYPE="SYNC",
+                                  i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
+                                  i_C0=clk_sdram_half_shifted,
+                                  i_C1=~clk_sdram_half_shifted,
+                                  o_Q=output_clk)
+        self.specials += Instance("OBUFDS", i_I=output_clk, o_O=clk.p, o_OB=clk.n)
+
+        # Peripheral clock - 50MHz
+        # ------------------------------------------------------------------------------
+        # The peripheral clock is kept separate from the system clock to allow
+        # the system clock to be increased in the future.
+        dcm_base50_locked = Signal()
+        self.specials += [
+            Instance("DCM_CLKGEN", name="crg_periph_dcm_clkgen",
+                     p_CLKIN_PERIOD=10.0,
+                     p_CLKFX_MULTIPLY=2,
+                     p_CLKFX_DIVIDE=4,
+                     p_CLKFX_MD_MAX=0.5, # CLKFX_MULTIPLY/CLKFX_DIVIDE
+                     p_CLKFXDV_DIVIDE=2,
+                     p_SPREAD_SPECTRUM="NONE",
+                     p_STARTUP_WAIT="FALSE",
+
+                     i_CLKIN=clk100a,
+                     o_CLKFX=self.cd_base50.clk,
+                     o_LOCKED=dcm_base50_locked,
+                     i_FREEZEDCM=0,
+                     i_RST=ResetSignal(),
+                     ),
+            AsyncResetSynchronizer(self.cd_base50,
+                self.cd_sys.rst | ~dcm_base50_locked)
+        ]
+        platform.add_period_constraint(self.cd_base50.clk, 20)
+
+        # Encoder clock - 66 MHz
+        # ------------------------------------------------------------------------------
+        self.specials += Instance("BUFG", name="encoder_bufg", i_I=unbuf_encoder, o_O=self.cd_encoder.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_encoder, self.cd_sys.rst)

--- a/targets/opsis/encoder.py
+++ b/targets/opsis/encoder.py
@@ -5,26 +5,20 @@ from litex.soc.interconnect import stream
 from gateware.encoder import EncoderDMAReader, EncoderBuffer, Encoder
 from gateware.streamer import USBStreamer
 
-from targets.utils import csr_map_update
 from targets.opsis.net import SoC as BaseSoC
 
 
 class EncoderSoC(BaseSoC):
-    csr_peripherals = (
-        "encoder_reader",
-        "encoder",
-    )
-    csr_map_update(BaseSoC.csr_map, csr_peripherals)
-    mem_map = {
-        "encoder": 0x50000000,  # (shadow @0xd0000000)
-    }
-    mem_map.update(BaseSoC.mem_map)
+    mem_map = {**BaseSoC.mem_map, **{
+        "encoder": 0x50000000,
+    }}
 
     def __init__(self, platform, *args, **kwargs):
         BaseSoC.__init__(self, platform, *args, **kwargs)
 
         encoder_port = self.sdram.crossbar.get_port()
         self.submodules.encoder_reader = EncoderDMAReader(encoder_port)
+        self.add_csr("encoder_reader")
         encoder_cdc = stream.AsyncFIFO([("data", 128)], 4)
         encoder_cdc = ClockDomainsRenamer({"write": "sys",
                                            "read": "encoder"})(encoder_cdc)
@@ -32,6 +26,7 @@ class EncoderSoC(BaseSoC):
         encoder = Encoder(platform)
         encoder_streamer = USBStreamer(platform, platform.request("fx2"))
         self.submodules += encoder_cdc, encoder_buffer, encoder, encoder_streamer
+        self.add_csr("encoder")
 
         self.comb += [
             self.encoder_reader.source.connect(encoder_cdc.sink),

--- a/targets/opsis/hdmi2usb.py
+++ b/targets/opsis/hdmi2usb.py
@@ -5,26 +5,20 @@ from litex.soc.interconnect import stream
 from gateware.encoder import EncoderDMAReader, EncoderBuffer, Encoder
 from gateware.streamer import USBStreamer
 
-from targets.utils import csr_map_update
 from targets.opsis.video import SoC as BaseSoC
 
 
 class HDMI2USBSoC(BaseSoC):
-    csr_peripherals = (
-        "encoder_reader",
-        "encoder",
-    )
-    csr_map_update(BaseSoC.csr_map, csr_peripherals)
-    mem_map = {
-        "encoder": 0x50000000,  # (shadow @0xd0000000)
-    }
-    mem_map.update(BaseSoC.mem_map)
+    mem_map = {**BaseSoC.mem_map, **{
+        "encoder": 0x50000000,
+    }}
 
     def __init__(self, platform, *args, **kwargs):
         BaseSoC.__init__(self, platform, *args, **kwargs)
 
         encoder_port = self.sdram.crossbar.get_port()
         self.submodules.encoder_reader = EncoderDMAReader(encoder_port)
+        self.add_csr("encoder_reader")
         encoder_cdc = stream.AsyncFIFO([("data", 128)], 4)
         encoder_cdc = ClockDomainsRenamer({"write": "sys",
                                            "read": "encoder"})(encoder_cdc)
@@ -32,6 +26,7 @@ class HDMI2USBSoC(BaseSoC):
         encoder = Encoder(platform)
         encoder_streamer = USBStreamer(platform, platform.request("fx2"))
         self.submodules += encoder_cdc, encoder_buffer, encoder, encoder_streamer
+        self.add_csr("encoder")
 
         self.comb += [
             self.encoder_reader.source.connect(encoder_cdc.sink),

--- a/targets/opsis/net.py
+++ b/targets/opsis/net.py
@@ -1,7 +1,8 @@
 from litex.soc.integration.soc_sdram import *
 
 from liteeth.core.mac import LiteEthMAC
-from liteeth.phy import LiteEthPHY
+
+from gateware.s6rgmii import LiteEthPHYRGMII
 
 from .base import BaseSoC
 
@@ -20,7 +21,7 @@ class NetSoC(BaseSoC):
 
         # Ethernet ---------------------------------------------------------------------------------
         # Ethernet PHY
-        self.submodules.ethphy = LiteEthPHY(
+        self.submodules.ethphy = LiteEthPHYRGMII(
             platform.request("eth_clocks"),
             platform.request("eth"))
         self.add_csr("ethphy")

--- a/targets/pano_logic_g2/base.py
+++ b/targets/pano_logic_g2/base.py
@@ -1,191 +1,88 @@
 # Support for the Pano Logic Zero Client G2
 from migen import *
-from migen.genlib.resetsync import AsyncResetSynchronizer
 
-from litex.soc.interconnect import wishbone
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
+from litex.soc.interconnect import wishbone
 
 from litedram.modules import MT47H32M16
 from litedram.phy import s6ddrphy
 from litedram.core import ControllerSettings
 
-from gateware import info
 from gateware import cas
+from gateware import info
+from gateware import spi_flash
 
-from targets.utils import csr_map_update
+from .crg import _CRG
 
-
-class _CRG(Module):
-    def __init__(self, platform):
-        self.clock_domains.cd_sys = ClockDomain()
-        self.clock_domains.cd_sdram_half = ClockDomain()
-        self.clock_domains.cd_sdram_full_wr = ClockDomain()
-        self.clock_domains.cd_sdram_full_rd = ClockDomain()
-
-        self.reset = Signal()
-
-        f0 = int(125e6)
-
-        clk125 = platform.request(platform.default_clk_name)
-        clk125a = Signal()
-
-        self.specials += Instance("IBUFG", i_I=clk125, o_O=clk125a)
-
-        clk125b = Signal()
-
-        self.specials += Instance(
-            "BUFIO2", p_DIVIDE=1,
-            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
-            i_I=clk125a, o_DIVCLK=clk125b)
-
-        unbuf_sdram_full = Signal()
-        unbuf_sdram_half_a = Signal()
-        unbuf_sdram_half_b = Signal()
-        unbuf_encoder = Signal()
-        unbuf_sys = Signal()
-        unbuf_unused = Signal()
-
-        # PLL signals
-        pll_lckd = Signal()
-        pll_fb = Signal()
-        self.specials.pll = Instance(
-            "PLL_ADV",
-            name="crg_pll_adv",
-            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
-            p_REF_JITTER=.01,
-            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
-            p_DIVCLK_DIVIDE=1,
-            # Input Clocks (125MHz)
-            i_CLKIN1=clk125b,
-            p_CLKIN1_PERIOD=platform.default_clk_period,
-            i_CLKIN2=0,
-            p_CLKIN2_PERIOD=0.,
-            i_CLKINSEL=1,
-            # Feedback
-            # (1000MHz) vco
-            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
-            p_CLK_FEEDBACK="CLKFBOUT",
-            p_CLKFBOUT_MULT=8, p_CLKFBOUT_PHASE=0.,
-            # (200MHz) sdram wr rd
-            o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
-            p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=5,
-            # (100MHz) unused
-            o_CLKOUT1=unbuf_encoder, p_CLKOUT1_DUTY_CYCLE=.5,
-            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=10,
-            # (100MHz) sdram_half - sdram dqs adr ctrl
-            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
-            p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=10,
-            # (100MHz) off-chip ddr
-            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
-            p_CLKOUT3_PHASE=250., p_CLKOUT3_DIVIDE=10,
-            # (100MHz) unused
-            o_CLKOUT4=unbuf_unused, p_CLKOUT4_DUTY_CYCLE=.5,
-            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=10,
-            # ( 50MHz) sysclk
-            o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
-            p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=20,
-        )
-
-        # power on reset?
-        reset = ~platform.request("cpu_reset") | self.reset
-        self.clock_domains.cd_por = ClockDomain()
-        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
-        self.sync.por += If(por != 0, por.eq(por - 1))
-        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
-
-        # System clock - 50MHz
-        self.specials += Instance("BUFG", name="sys_bufg", i_I=unbuf_sys, o_O=self.cd_sys.clk)
-        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
-        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
-
-        # SDRAM clocks
-        # ------------------------------------------------------------------------------
-        self.clk4x_wr_strb = Signal()
-        self.clk4x_rd_strb = Signal()
-
-        # sdram_full
-        self.specials += Instance("BUFPLL", name="sdram_full_bufpll",
-                                  p_DIVIDE=4,
-                                  i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys.clk,
-                                  i_LOCKED=pll_lckd,
-                                  o_IOCLK=self.cd_sdram_full_wr.clk,
-                                  o_SERDESSTROBE=self.clk4x_wr_strb)
-        self.comb += [
-            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
-            self.clk4x_rd_strb.eq(self.clk4x_wr_strb),
-        ]
-        # sdram_half
-        self.specials += Instance("BUFG", name="sdram_half_a_bufpll", i_I=unbuf_sdram_half_a, o_O=self.cd_sdram_half.clk)
-        clk_sdram_half_shifted = Signal()
-        self.specials += Instance("BUFG", name="sdram_half_b_bufpll", i_I=unbuf_sdram_half_b, o_O=clk_sdram_half_shifted)
-
-        output_clk = Signal()
-        clk = platform.request("ddram_clock_b")
-        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
-                                  p_INIT=0, p_SRTYPE="SYNC",
-                                  i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
-                                  i_C0=clk_sdram_half_shifted,
-                                  i_C1=~clk_sdram_half_shifted,
-                                  o_Q=output_clk)
-        self.specials += Instance("OBUFDS", i_I=output_clk, o_O=clk.p, o_OB=clk.n)
 
 class BaseSoC(SoCSDRAM):
-    csr_peripherals = (
-        "ddrphy",
-        "info",
-        "cas",
-    )
-    csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
-
-    mem_map = {
-        "emulator_ram": 0x50000000,  # (default shadow @0xd0000000)
-    }
-    mem_map.update(SoCSDRAM.mem_map)
+    mem_map = {**SoCSDRAM.mem_map, **{
+        spiflash=0x20000000,
+    }}
 
     def __init__(self, platform, **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0x8000
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x8000
+        kwargs['integrated_rom_size']=0x8000
+        kwargs['integrated_sram_size']=0x8000
 
-        clk_freq = int(50e6)
-        SoCSDRAM.__init__(self, platform, clk_freq, **kwargs)
+        sys_clk_freq = int(50e6)
+        # SoCSDRAM ---------------------------------------------------------------------------------
+        SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq, **kwargs)
 
-        self.submodules.crg = _CRG(platform)
-        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/clk_freq)
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/sys_clk_freq)
 
+        # DDR2 SDRAM -------------------------------------------------------------------------------
+        if True:
+            sdram_module = MT47H32M16(sys_clk_freq, "1:2")
+            self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
+                platform.request("ddram_b"),
+                memtype      = sdram_module.memtype,
+                rd_bitslip   = 0,
+                wr_bitslip   = 4,
+                dqs_ddr_alignment="C0")
+            self.add_csr("ddrphy")
+            controller_settings = ControllerSettings(
+                with_bandwidth=True)
+            self.register_sdram(
+                self.ddrphy,
+                geom_settings   = sdram_module.geom_settings,
+                timing_settings = sdram_module.timing_settings,
+                controller_settings=controller_settings)
+            self.comb += [
+                self.ddrphy.clk4x_wr_strb.eq(self.crg.clk4x_wr_strb),
+                self.ddrphy.clk4x_rd_strb.eq(self.crg.clk4x_rd_strb),
+            ]
+
+        # Basic peripherals ------------------------------------------------------------------------
+        # info module
         self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.add_csr("info")
+        # control and status module
         self.submodules.cas = cas.ControlAndStatus(platform, clk_freq)
+        self.add_csr("cas")
 
+        # Add debug interface if the CPU has one ---------------------------------------------------
+        if hasattr(self.cpu, "debug_bus"):
+            self.register_mem(
+                name="vexriscv_debug",
+                address=0xf00f0000,
+                interface=self.cpu.debug_bus,
+                size=0x100)
+
+        # ??????
         gmii_rst_n = platform.request("gmii_rst_n")
-
         self.comb += [
             gmii_rst_n.eq(1)
         ]
 
+
+        # Support for soft-emulation for full Linux support ----------------------------------------
         if self.cpu_type == "vexriscv" and self.cpu_variant == "linux":
             size = 0x4000
             self.submodules.emulator_ram = wishbone.SRAM(size)
             self.register_mem("emulator_ram", self.mem_map["emulator_ram"], self.emulator_ram.bus, size)
-
-        # sdram
-        sdram_module = MT47H32M16(self.clk_freq, "1:2")
-        self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
-            platform.request("ddram_b"),
-            sdram_module.memtype,
-            rd_bitslip=0,
-            wr_bitslip=4,
-            dqs_ddr_alignment="C0")
-        controller_settings = ControllerSettings(with_bandwidth=True)
-        self.register_sdram(self.ddrphy,
-                            sdram_module.geom_settings,
-                            sdram_module.timing_settings,
-                            controller_settings=controller_settings)
-        self.comb += [
-            self.ddrphy.clk4x_wr_strb.eq(self.crg.clk4x_wr_strb),
-            self.ddrphy.clk4x_rd_strb.eq(self.crg.clk4x_rd_strb),
-        ]
 
 
 SoC = BaseSoC

--- a/targets/pano_logic_g2/crg.py
+++ b/targets/pano_logic_g2/crg.py
@@ -1,0 +1,119 @@
+# Support for the Pano Logic Zero Client G2
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq):
+        self.clock_domains.cd_sys = ClockDomain()
+        self.clock_domains.cd_sdram_half = ClockDomain()
+        self.clock_domains.cd_sdram_full_wr = ClockDomain()
+        self.clock_domains.cd_sdram_full_rd = ClockDomain()
+
+        self.reset = Signal()
+
+        f0 = int(125e6)
+
+        clk125 = platform.request(platform.default_clk_name)
+        clk125a = Signal()
+
+        self.specials += Instance("IBUFG", i_I=clk125, o_O=clk125a)
+
+        clk125b = Signal()
+
+        self.specials += Instance(
+            "BUFIO2", p_DIVIDE=1,
+            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
+            i_I=clk125a, o_DIVCLK=clk125b)
+
+        unbuf_sdram_full = Signal()
+        unbuf_sdram_half_a = Signal()
+        unbuf_sdram_half_b = Signal()
+        unbuf_encoder = Signal()
+        unbuf_sys = Signal()
+        unbuf_unused = Signal()
+
+        # PLL signals
+        pll_lckd = Signal()
+        pll_fb = Signal()
+        self.specials.pll = Instance(
+            "PLL_ADV",
+            name="crg_pll_adv",
+            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
+            p_REF_JITTER=.01,
+            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
+            p_DIVCLK_DIVIDE=1,
+            # Input Clocks (125MHz)
+            i_CLKIN1=clk125b,
+            p_CLKIN1_PERIOD=platform.default_clk_period,
+            i_CLKIN2=0,
+            p_CLKIN2_PERIOD=0.,
+            i_CLKINSEL=1,
+            # Feedback
+            # (1000MHz) vco
+            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
+            p_CLK_FEEDBACK="CLKFBOUT",
+            p_CLKFBOUT_MULT=8, p_CLKFBOUT_PHASE=0.,
+            # (200MHz) sdram wr rd
+            o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
+            p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=5,
+            # (100MHz) unused
+            o_CLKOUT1=unbuf_encoder, p_CLKOUT1_DUTY_CYCLE=.5,
+            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=10,
+            # (100MHz) sdram_half - sdram dqs adr ctrl
+            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
+            p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=10,
+            # (100MHz) off-chip ddr
+            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
+            p_CLKOUT3_PHASE=250., p_CLKOUT3_DIVIDE=10,
+            # (100MHz) unused
+            o_CLKOUT4=unbuf_unused, p_CLKOUT4_DUTY_CYCLE=.5,
+            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=10,
+            # ( 50MHz) sysclk
+            o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
+            p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=20,
+        )
+
+        # power on reset?
+        reset = ~platform.request("cpu_reset") | self.reset
+        self.clock_domains.cd_por = ClockDomain()
+        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
+        self.sync.por += If(por != 0, por.eq(por - 1))
+        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
+
+        # System clock - 50MHz
+        self.specials += Instance("BUFG", name="sys_bufg", i_I=unbuf_sys, o_O=self.cd_sys.clk)
+        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
+
+        # SDRAM clocks
+        # ------------------------------------------------------------------------------
+        self.clk4x_wr_strb = Signal()
+        self.clk4x_rd_strb = Signal()
+
+        # sdram_full
+        self.specials += Instance("BUFPLL", name="sdram_full_bufpll",
+                                  p_DIVIDE=4,
+                                  i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys.clk,
+                                  i_LOCKED=pll_lckd,
+                                  o_IOCLK=self.cd_sdram_full_wr.clk,
+                                  o_SERDESSTROBE=self.clk4x_wr_strb)
+        self.comb += [
+            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
+            self.clk4x_rd_strb.eq(self.clk4x_wr_strb),
+        ]
+        # sdram_half
+        self.specials += Instance("BUFG", name="sdram_half_a_bufpll", i_I=unbuf_sdram_half_a, o_O=self.cd_sdram_half.clk)
+        clk_sdram_half_shifted = Signal()
+        self.specials += Instance("BUFG", name="sdram_half_b_bufpll", i_I=unbuf_sdram_half_b, o_O=clk_sdram_half_shifted)
+
+        output_clk = Signal()
+        clk = platform.request("ddram_clock_b")
+        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
+                                  p_INIT=0, p_SRTYPE="SYNC",
+                                  i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
+                                  i_C0=clk_sdram_half_shifted,
+                                  i_C1=~clk_sdram_half_shifted,
+                                  o_Q=output_clk)
+        self.specials += Instance("OBUFDS", i_I=output_clk, o_O=clk.p, o_OB=clk.n)

--- a/targets/pipistrello/base.py
+++ b/targets/pipistrello/base.py
@@ -1,4 +1,7 @@
 # Support for the Pipistrello - http://pipistrello.saanlima.com/
+
+from fractions import Fraction
+
 from migen import *
 
 from litex.soc.integration.soc_sdram import *

--- a/targets/pipistrello/base.py
+++ b/targets/pipistrello/base.py
@@ -1,11 +1,9 @@
 # Support for the Pipistrello - http://pipistrello.saanlima.com/
-from fractions import Fraction
-
 from migen import *
-from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
+from litex.soc.interconnect import wishbone
 
 from litedram.modules import MT46H32M16
 from litedram.phy import s6ddrphy
@@ -15,222 +13,92 @@ from litedram.core import ControllerSettings
 from gateware import info
 from gateware import spi_flash
 
-from targets.utils import csr_map_update
-
-
-class _CRG(Module):
-    def __init__(self, platform, clk_freq):
-        # Clock domains for the system (soft CPU and related components run at).
-        self.clock_domains.cd_sys = ClockDomain()
-        # Clock domains for the DDR interface.
-        self.clock_domains.cd_sdram_half = ClockDomain()
-        self.clock_domains.cd_sdram_full_wr = ClockDomain()
-        self.clock_domains.cd_sdram_full_rd = ClockDomain()
-        # Clock domain for peripherals (such as HDMI output).
-        self.clock_domains.cd_base50 = ClockDomain()
-
-        self.reset = Signal()
-
-        # Input 50MHz clock
-        f0 = 50*1000000
-        clk50 = platform.request("clk50")
-        clk50a = Signal()
-        # Input 50MHz clock (buffered)
-        self.specials += Instance("IBUFG", i_I=clk50, o_O=clk50a)
-        clk50b = Signal()
-        self.specials += Instance(
-            "BUFIO2", p_DIVIDE=1,
-            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
-            i_I=clk50a, o_DIVCLK=clk50b)
-
-        p = 12
-        f = Fraction(clk_freq*p, f0)
-        n, d = f.numerator, f.denominator
-        assert 19e6 <= f0/d <= 500e6  # pfd
-        assert 400e6 <= f0*n/d <= 1080e6  # vco
-
-        # Unbuffered output signals from the PLL. They need to be buffered
-        # before feeding into the fabric.
-        unbuf_sdram_full = Signal()
-        unbuf_sdram_half_a = Signal()
-        unbuf_sdram_half_b = Signal()
-        unbuf_unused = Signal()
-        unbuf_sys = Signal()
-        unbuf_periph = Signal()
-
-        # PLL signals
-        pll_lckd = Signal()
-        pll_fb = Signal()
-        self.specials.pll = Instance(
-            "PLL_ADV",
-            name="crg_pll_adv",
-            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
-            p_REF_JITTER=.01,
-            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
-            p_DIVCLK_DIVIDE=d,
-            # Input Clocks (50MHz)
-            i_CLKIN1=clk50b,
-            p_CLKIN1_PERIOD=1e9/f0,
-            i_CLKIN2=0,
-            p_CLKIN2_PERIOD=0.,
-            i_CLKINSEL=1,
-            # Feedback
-            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
-            p_CLK_FEEDBACK="CLKFBOUT",
-            p_CLKFBOUT_MULT=n, p_CLKFBOUT_PHASE=0.,
-            # (333MHz) sdram wr rd
-            o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
-            p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//4,
-            # unused?
-            o_CLKOUT1=unbuf_unused, p_CLKOUT1_DUTY_CYCLE=.5,
-            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=15,
-            # (166MHz) sdram_half - sdram dqs adr ctrl
-            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
-            p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=p//2,
-            # (166MHz) off-chip ddr
-            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
-            p_CLKOUT3_PHASE=250., p_CLKOUT3_DIVIDE=p//2,
-            # ( 50MHz) periph
-            o_CLKOUT4=unbuf_periph, p_CLKOUT4_DUTY_CYCLE=.5,
-            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=20,
-            # ( 83MHz) sysclk
-            o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
-            p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=p//1,
-        )
-
-
-        # power on reset?
-        reset = platform.request("user_btn") | self.reset
-        self.clock_domains.cd_por = ClockDomain()
-        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
-        self.sync.por += If(por != 0, por.eq(por - 1))
-        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
-
-        # System clock - 75MHz
-        self.specials += Instance("BUFG", i_I=unbuf_sys, o_O=self.cd_sys.clk)
-        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
-        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
-
-
-        # SDRAM clocks
-        # ------------------------------------------------------------------------------
-        self.clk4x_wr_strb = Signal()
-        self.clk4x_rd_strb = Signal()
-
-        # sdram_full
-        self.specials += Instance("BUFPLL", name="sdram_full_bufpll",
-                                  p_DIVIDE=4,
-                                  i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys.clk,
-                                  i_LOCKED=pll_lckd,
-                                  o_IOCLK=self.cd_sdram_full_wr.clk,
-                                  o_SERDESSTROBE=self.clk4x_wr_strb)
-        self.comb += [
-            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
-            self.clk4x_rd_strb.eq(self.clk4x_wr_strb),
-        ]
-        # sdram_half
-        self.specials += Instance("BUFG", name="sdram_half_a_bufpll", i_I=unbuf_sdram_half_a, o_O=self.cd_sdram_half.clk)
-        clk_sdram_half_shifted = Signal()
-        self.specials += Instance("BUFG", name="sdram_half_b_bufpll", i_I=unbuf_sdram_half_b, o_O=clk_sdram_half_shifted)
-        clk = platform.request("ddram_clock")
-        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
-                                  p_INIT=0, p_SRTYPE="SYNC",
-                                  i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
-                                  i_C0=clk_sdram_half_shifted,
-                                  i_C1=~clk_sdram_half_shifted,
-                                  o_Q=clk.p)
-        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
-                                  p_INIT=0, p_SRTYPE="SYNC",
-                                  i_D0=0, i_D1=1, i_S=0, i_R=0, i_CE=1,
-                                  i_C0=clk_sdram_half_shifted, i_C1=~clk_sdram_half_shifted,
-                                  o_Q=clk.n)
-
-        # Peripheral clock - 50MHz
-        # ------------------------------------------------------------------------------
-        # The peripheral clock is kept separate from the system clock to allow
-        # the system clock to be increased in the future.
-        dcm_base50_locked = Signal()
-        self.specials += [
-            Instance("DCM_CLKGEN", name="crg_periph_dcm_clkgen",
-                     p_CLKIN_PERIOD=20.0,
-                     p_CLKFX_MULTIPLY=2,
-                     p_CLKFX_DIVIDE=2,
-                     p_CLKFX_MD_MAX=1.0, # CLKFX_MULTIPLY/CLKFX_DIVIDE
-                     p_CLKFXDV_DIVIDE=2,
-                     p_SPREAD_SPECTRUM="NONE",
-                     p_STARTUP_WAIT="FALSE",
-
-                     i_CLKIN=clk50a,
-                     o_CLKFX=self.cd_base50.clk,
-                     o_LOCKED=dcm_base50_locked,
-                     i_FREEZEDCM=0,
-                     i_RST=ResetSignal(),
-                     ),
-            AsyncResetSynchronizer(self.cd_base50,
-                self.cd_sys.rst | ~dcm_base50_locked)
-        ]
-        platform.add_period_constraint(self.cd_base50.clk, 20)
+from .crg import _CRG
 
 
 class BaseSoC(SoCSDRAM):
-    csr_peripherals = (
-        "spiflash",
-        "front_panel",
-        "ddrphy",
-        "info",
-    )
-    csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
-
-    mem_map = {
-        "spiflash":     0x20000000,  # (default shadow @0xa0000000)
-    }
-    mem_map.update(SoCSDRAM.mem_map)
-
+    mem_map = {**SoCSDRAM.mem_map, **{
+        'spiflash': 0x20000000,
+    }}
 
     def __init__(self, platform, **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0x8000
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x4000
+        kwargs['integrated_rom_size']=0x8000
+        kwargs['integrated_sram_size']=0x4000
 
-        clk_freq = (83 + Fraction(1, 3))*1000*1000
+        sys_clk_freq = (83 + Fraction(1, 3))*1000*1000
+        # SoCSDRAM ---------------------------------------------------------------------------------
+        SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq, **kwargs)
 
-        SoCSDRAM.__init__(self, platform, clk_freq, **kwargs)
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/sys_clk_freq)
 
-        self.submodules.crg = _CRG(platform, clk_freq)
-        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/clk_freq)
+        # DDR2 SDRAM -------------------------------------------------------------------------------
+        if True:
+            sdram_module = MT46H32M16(sys_clk_freq, "1:2")
+            self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
+                platform.request("ddram"),
+                memtype      = sdram_module.memtype,
+                rd_bitslip   = 1,
+                wr_bitslip   = 3,
+                dqs_ddr_alignment="C1")
+            self.add_csr("ddrphy")
+            controller_settings = ControllerSettings(
+                with_bandwidth=True)
+            self.register_sdram(
+                self.ddrphy,
+                geom_settings   = sdram_module.geom_settings,
+                timing_settings = sdram_module.timing_settings,
+                controller_settings=controller_settings)
+            self.comb += [
+                self.ddrphy.clk4x_wr_strb.eq(self.crg.clk4x_wr_strb),
+                self.ddrphy.clk4x_rd_strb.eq(self.crg.clk4x_rd_strb),
+            ]
 
+        # Basic peripherals ------------------------------------------------------------------------
+        # info module
         self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.add_csr("info")
+        # control and status module
+        #self.submodules.cas = cas.ControlAndStatus(platform, sys_clk_freq)
+        self.add_csr("cas")
 
+        # Add debug interface if the CPU has one ---------------------------------------------------
+        if hasattr(self.cpu, "debug_bus"):
+            self.register_mem(
+                name="vexriscv_debug",
+                address=0xf00f0000,
+                interface=self.cpu.debug_bus,
+                size=0x100)
+
+        # Memory mapped SPI Flash ------------------------------------------------------------------
         self.submodules.spiflash = spi_flash.SpiFlash(
             platform.request("spiflash4x"),
             dummy=platform.spiflash_read_dummy_bits,
-            div=platform.spiflash_clock_div)
+            div=platform.spiflash_clock_div,
+            endianness=self.cpu.endianness)
+        self.add_csr("spiflash")
         self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
         self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
-        self.register_mem("spiflash", self.mem_map["spiflash"],
-            self.spiflash.bus, size=platform.spiflash_total_size)
+        self.add_constant("SPIFLASH_TOTAL_SIZE", platform.spiflash_total_size)
+        self.add_wb_slave(
+            self.mem_map["spiflash"],
+            self.spiflash.bus,
+            platform.spiflash_total_size)
+        self.add_memory_region(
+            "spiflash",
+            self.mem_map["spiflash"],
+            platform.spiflash_total_size)
 
         bios_size = 0x8000
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
         self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
-        # sdram
-        sdram_module = MT46H32M16(self.clk_freq, "1:2")
-        self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
-            platform.request("ddram"),
-            sdram_module.memtype,
-            rd_bitslip=1,
-            wr_bitslip=3,
-            dqs_ddr_alignment="C1")
-        controller_settings = ControllerSettings(with_bandwidth=True)
-        self.register_sdram(self.ddrphy,
-                            sdram_module.geom_settings,
-                            sdram_module.timing_settings,
-                            controller_settings=controller_settings)
-        self.comb += [
-            self.ddrphy.clk4x_wr_strb.eq(self.crg.clk4x_wr_strb),
-            self.ddrphy.clk4x_rd_strb.eq(self.crg.clk4x_rd_strb),
-        ]
+
+        # Support for soft-emulation for full Linux support ----------------------------------------
+        if self.cpu_type == "vexriscv" and self.cpu_variant == "linux":
+            size = 0x4000
+            self.submodules.emulator_ram = wishbone.SRAM(size)
+            self.register_mem("emulator_ram", self.mem_map["emulator_ram"], self.emulator_ram.bus, size)
 
 
 SoC = BaseSoC

--- a/targets/pipistrello/crg.py
+++ b/targets/pipistrello/crg.py
@@ -1,0 +1,160 @@
+# Support for the Pipistrello - http://pipistrello.saanlima.com/
+
+from fractions import Fraction
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+
+class _CRG(Module):
+    def __init__(self, platform, clk_freq):
+        # Clock domains for the system (soft CPU and related components run at).
+        self.clock_domains.cd_sys = ClockDomain()
+        # Clock domains for the DDR interface.
+        self.clock_domains.cd_sdram_half = ClockDomain()
+        self.clock_domains.cd_sdram_full_wr = ClockDomain()
+        self.clock_domains.cd_sdram_full_rd = ClockDomain()
+        # Clock domain for peripherals (such as HDMI output).
+        self.clock_domains.cd_base50 = ClockDomain()
+
+        self.reset = Signal()
+
+        # Input 50MHz clock
+        f0 = 50*1000000
+        clk50 = platform.request("clk50")
+        clk50a = Signal()
+        # Input 50MHz clock (buffered)
+        self.specials += Instance("IBUFG", i_I=clk50, o_O=clk50a)
+        clk50b = Signal()
+        self.specials += Instance(
+            "BUFIO2", p_DIVIDE=1,
+            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
+            i_I=clk50a, o_DIVCLK=clk50b)
+
+        p = 12
+        f = Fraction(clk_freq*p, f0)
+        n, d = f.numerator, f.denominator
+        assert 19e6 <= f0/d <= 500e6  # pfd
+        assert 400e6 <= f0*n/d <= 1080e6  # vco
+
+        # Unbuffered output signals from the PLL. They need to be buffered
+        # before feeding into the fabric.
+        unbuf_sdram_full = Signal()
+        unbuf_sdram_half_a = Signal()
+        unbuf_sdram_half_b = Signal()
+        unbuf_unused = Signal()
+        unbuf_sys = Signal()
+        unbuf_periph = Signal()
+
+        # PLL signals
+        pll_lckd = Signal()
+        pll_fb = Signal()
+        self.specials.pll = Instance(
+            "PLL_ADV",
+            name="crg_pll_adv",
+            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
+            p_REF_JITTER=.01,
+            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
+            p_DIVCLK_DIVIDE=d,
+            # Input Clocks (50MHz)
+            i_CLKIN1=clk50b,
+            p_CLKIN1_PERIOD=1e9/f0,
+            i_CLKIN2=0,
+            p_CLKIN2_PERIOD=0.,
+            i_CLKINSEL=1,
+            # Feedback
+            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
+            p_CLK_FEEDBACK="CLKFBOUT",
+            p_CLKFBOUT_MULT=n, p_CLKFBOUT_PHASE=0.,
+            # (333MHz) sdram wr rd
+            o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
+            p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=p//4,
+            # unused?
+            o_CLKOUT1=unbuf_unused, p_CLKOUT1_DUTY_CYCLE=.5,
+            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=15,
+            # (166MHz) sdram_half - sdram dqs adr ctrl
+            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
+            p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=p//2,
+            # (166MHz) off-chip ddr
+            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
+            p_CLKOUT3_PHASE=250., p_CLKOUT3_DIVIDE=p//2,
+            # ( 50MHz) periph
+            o_CLKOUT4=unbuf_periph, p_CLKOUT4_DUTY_CYCLE=.5,
+            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=20,
+            # ( 83MHz) sysclk
+            o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
+            p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=p//1,
+        )
+
+
+        # power on reset?
+        reset = platform.request("user_btn") | self.reset
+        self.clock_domains.cd_por = ClockDomain()
+        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
+        self.sync.por += If(por != 0, por.eq(por - 1))
+        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
+
+        # System clock - 75MHz
+        self.specials += Instance("BUFG", i_I=unbuf_sys, o_O=self.cd_sys.clk)
+        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
+
+
+        # SDRAM clocks
+        # ------------------------------------------------------------------------------
+        self.clk4x_wr_strb = Signal()
+        self.clk4x_rd_strb = Signal()
+
+        # sdram_full
+        self.specials += Instance("BUFPLL", name="sdram_full_bufpll",
+                                  p_DIVIDE=4,
+                                  i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys.clk,
+                                  i_LOCKED=pll_lckd,
+                                  o_IOCLK=self.cd_sdram_full_wr.clk,
+                                  o_SERDESSTROBE=self.clk4x_wr_strb)
+        self.comb += [
+            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
+            self.clk4x_rd_strb.eq(self.clk4x_wr_strb),
+        ]
+        # sdram_half
+        self.specials += Instance("BUFG", name="sdram_half_a_bufpll", i_I=unbuf_sdram_half_a, o_O=self.cd_sdram_half.clk)
+        clk_sdram_half_shifted = Signal()
+        self.specials += Instance("BUFG", name="sdram_half_b_bufpll", i_I=unbuf_sdram_half_b, o_O=clk_sdram_half_shifted)
+        clk = platform.request("ddram_clock")
+        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
+                                  p_INIT=0, p_SRTYPE="SYNC",
+                                  i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
+                                  i_C0=clk_sdram_half_shifted,
+                                  i_C1=~clk_sdram_half_shifted,
+                                  o_Q=clk.p)
+        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
+                                  p_INIT=0, p_SRTYPE="SYNC",
+                                  i_D0=0, i_D1=1, i_S=0, i_R=0, i_CE=1,
+                                  i_C0=clk_sdram_half_shifted, i_C1=~clk_sdram_half_shifted,
+                                  o_Q=clk.n)
+
+        # Peripheral clock - 50MHz
+        # ------------------------------------------------------------------------------
+        # The peripheral clock is kept separate from the system clock to allow
+        # the system clock to be increased in the future.
+        dcm_base50_locked = Signal()
+        self.specials += [
+            Instance("DCM_CLKGEN", name="crg_periph_dcm_clkgen",
+                     p_CLKIN_PERIOD=20.0,
+                     p_CLKFX_MULTIPLY=2,
+                     p_CLKFX_DIVIDE=2,
+                     p_CLKFX_MD_MAX=1.0, # CLKFX_MULTIPLY/CLKFX_DIVIDE
+                     p_CLKFXDV_DIVIDE=2,
+                     p_SPREAD_SPECTRUM="NONE",
+                     p_STARTUP_WAIT="FALSE",
+
+                     i_CLKIN=clk50a,
+                     o_CLKFX=self.cd_base50.clk,
+                     o_LOCKED=dcm_base50_locked,
+                     i_FREEZEDCM=0,
+                     i_RST=ResetSignal(),
+                     ),
+            AsyncResetSynchronizer(self.cd_base50,
+                self.cd_sys.rst | ~dcm_base50_locked)
+        ]
+        platform.add_period_constraint(self.cd_base50.clk, 20)

--- a/targets/saturn/base.py
+++ b/targets/saturn/base.py
@@ -1,229 +1,84 @@
 # Support for the Numato Saturn (http://numato.com/product/saturn-spartan-6-fpga-development-board-with-ddr-sdram)
-
-from fractions import Fraction
-
 from migen import *
-from migen.genlib.resetsync import AsyncResetSynchronizer
-
-from litex.build.generic_platform import *
 
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
+from litex.soc.interconnect import wishbone
 
 from litedram.modules import MT46H32M16
 from litedram.phy import s6ddrphy
 from litedram.core import ControllerSettings
 
-from targets.utils import csr_map_update
+#from gateware import cas
+from gateware import info
+from gateware import spi_flash
 
+from .crg import _CRG
 
-class _CRG(Module):
-    def __init__(self, platform, clk_freq):
-        # Clock domains for the system (soft CPU and related components run at).
-        self.clock_domains.cd_sys = ClockDomain()
-        # Clock domains for the DDR interface.
-        self.clock_domains.cd_sdram_half = ClockDomain()
-        self.clock_domains.cd_sdram_full_wr = ClockDomain()
-        self.clock_domains.cd_sdram_full_rd = ClockDomain()
-
-        # Input 100MHz clock
-        f0 = Fraction(100, 1)*1000000
-        clk100 = platform.request("clk100")
-        clk100a = Signal()
-        # Input 100MHz clock (buffered)
-        self.specials += Instance(
-            "IBUFG",
-            i_I=clk100,
-            o_O=clk100a
-        )
-
-        clk100b = Signal()
-
-        self.specials += Instance(
-            "BUFIO2",
-            p_DIVIDE=1,
-            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
-            i_I=clk100a,
-            o_DIVCLK=clk100b
-        )
-
-        #PLL parameters
-        f = Fraction(10, 1)
-        n, d = f.numerator, f.denominator
-        p = 8
-
-        assert f0*n/d/p/4 == clk_freq
-        assert 19e6     <= f0/d     <= 500e6    # pfd
-        assert 400e6    <= f0*n/d   <= 1000e6   # vco
-
-        # Unbuffered output signals from the PLL. They need to be buffered
-        # before feeding into the fabric.
-        unbuf_sdram_full    = Signal()
-        unbuf_sdram_half_a  = Signal()
-        unbuf_sdram_half_b  = Signal()
-        unbuf_unused_a      = Signal()
-        unbuf_unused_b      = Signal()
-        unbuf_sys           = Signal()
-
-        # PLL signals
-        pll_lckd = Signal()
-        pll_fb = Signal()
-        self.specials.pll = Instance(
-            "PLL_ADV",
-            name="crg_pll_adv",
-            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
-            p_REF_JITTER=.01,
-            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
-            p_DIVCLK_DIVIDE=d,
-            # Input Clocks (100MHz)
-            i_CLKIN1=clk100b,
-            p_CLKIN1_PERIOD=1e9/f0,
-            i_CLKIN2=0,
-            p_CLKIN2_PERIOD=0.,
-            i_CLKINSEL=1,
-            # Feedback
-            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
-            p_CLK_FEEDBACK="CLKFBOUT",
-            p_CLKFBOUT_MULT=n, p_CLKFBOUT_PHASE=0.,
-            # Outputs
-            # (125 MHz) sdram wr rd
-            o_CLKOUT0=unbuf_sdram_full,   p_CLKOUT0_DUTY_CYCLE=.5,
-            p_CLKOUT0_PHASE=0.,   p_CLKOUT0_DIVIDE=p,
-            # (125 MHz) unused
-            o_CLKOUT1=unbuf_unused_a,     p_CLKOUT1_DUTY_CYCLE=.5,
-            p_CLKOUT1_PHASE=0.,   p_CLKOUT1_DIVIDE=p,
-            # (62.5 MHz) sdram_half - sdram dqs adr ctrl
-            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
-            p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=(p*2),
-            # (62.5 MHz) off-chip ddr
-            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
-            p_CLKOUT3_PHASE=270., p_CLKOUT3_DIVIDE=(p*2),
-            # (31.25 MHz) unused
-            o_CLKOUT4=unbuf_unused_b,     p_CLKOUT4_DUTY_CYCLE=.5,
-            p_CLKOUT4_PHASE=0.,   p_CLKOUT4_DIVIDE=(p*4),
-            # (31.25 MHz) sysclk
-            o_CLKOUT5=unbuf_sys,          p_CLKOUT5_DUTY_CYCLE=.5,
-            p_CLKOUT5_PHASE=0.,   p_CLKOUT5_DIVIDE=(p*4),
-        )
-
-        #power on reset?
-        reset_pin = [("reset", 0, Pins("P2:0")), ]
-        platform.add_extension(reset_pin)
-        reset = platform.request("reset")
-        self.clock_domains.cd_por = ClockDomain()
-        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
-        self.sync.por += If(por != 0, por.eq(por - 1))
-        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
-
-        #System clock
-        self.specials += Instance("BUFG", i_I=unbuf_sys, o_O=self.cd_sys.clk)
-        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
-        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
-
-        # SDRAM clocks
-        # ------------------------------------------------------------------------------
-        self.clk4x_wr_strb = Signal()
-        self.clk4x_rd_strb = Signal()
-
-        # sdram_full
-        self.specials += Instance(
-            "BUFPLL",
-            p_DIVIDE=4,
-            i_PLLIN=unbuf_sdram_full,
-            i_GCLK=self.cd_sys.clk,
-            i_LOCKED=pll_lckd,
-            o_IOCLK=self.cd_sdram_full_wr.clk,
-            o_SERDESSTROBE=self.clk4x_wr_strb
-        )
-
-        self.comb += [
-            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
-            self.clk4x_rd_strb.eq(self.clk4x_wr_strb),
-        ]
-
-        # sdram_half
-        self.specials += Instance(
-            "BUFG",
-            i_I=unbuf_sdram_half_a,
-            o_O=self.cd_sdram_half.clk
-        )
-
-        clk_sdram_half_shifted = Signal()
-        self.specials += Instance(
-            "BUFG",
-            i_I=unbuf_sdram_half_b,
-            o_O=clk_sdram_half_shifted
-        )
-
-        clk = platform.request("ddram_clock")
-        self.specials += Instance(
-            "ODDR2",
-            p_DDR_ALIGNMENT="NONE",
-            p_INIT=0, p_SRTYPE="SYNC",
-            i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
-            i_C0=clk_sdram_half_shifted,
-            i_C1=~clk_sdram_half_shifted,
-            o_Q=clk.p
-        )
-
-        self.specials += Instance(
-            "ODDR2",
-            p_DDR_ALIGNMENT="NONE",
-            p_INIT=0, p_SRTYPE="SYNC",
-            i_D0=0, i_D1=1, i_S=0, i_R=0, i_CE=1,
-            i_C0=clk_sdram_half_shifted,
-            i_C1=~clk_sdram_half_shifted,
-            o_Q=clk.n
-        )
 
 class BaseSoC(SoCSDRAM):
-    csr_peripherals = (
-        "ddrphy",
-    )
-    csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
-
-    # FIXME: Add spiflash
-    #mem_map = {
-    #    "spiflash": 0x20000000,  # (default shadow @0xa0000000)
-    #}
-    #mem_map.update(SoCSDRAM.mem_map)
+    mem_map = {**SoCSDRAM.mem_map, **{
+        spiflash=0x20000000,
+    }}
 
     def __init__(self, platform, **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0x8000
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x4000
+        kwargs['integrated_rom_size']=0x8000
+        kwargs['integrated_sram_size']=0x4000
+
+        sys_clk_freq = (31 + Fraction(1, 4))*1000*1000
+        # SoCSDRAM ---------------------------------------------------------------------------------
+        SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq, **kwargs)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
 
 
-        clk_freq = (31 + Fraction(1, 4))*1000*1000
+        # DDR2 SDRAM -------------------------------------------------------------------------------
+        if True:
+            sdram_module = MT46H32M16(sys_clk_freq, "1:2")
+            self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
+                platform.request("ddram"),
+                memtype      = sdram_module.memtype,
+                rd_bitslip   = 2,
+                wr_bitslip   = 3,
+                dqs_ddr_alignment="C1")
+            self.add_csr("ddrphy")
+            controller_settings = ControllerSettings(
+                with_bandwidth=True)
+            self.register_sdram(
+                self.ddrphy,
+                geom_settings   = sdram_module.geom_settings,
+                timing_settings = sdram_module.timing_settings,
+                controller_settings=controller_settings)
+            self.comb += [
+                self.ddrphy.clk4x_wr_strb.eq(self.crg.clk4x_wr_strb),
+                self.ddrphy.clk4x_rd_strb.eq(self.crg.clk4x_rd_strb),
+            ]
 
-        SoCSDRAM.__init__(self, platform, clk_freq, **kwargs)
+        # Basic peripherals ------------------------------------------------------------------------
+        # info module
+        self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.add_csr("info")
+        # control and status module
+        #self.submodules.cas = cas.ControlAndStatus(platform, sys_clk_freq)
+        self.add_csr("cas")
 
-        self.submodules.crg = _CRG(platform, clk_freq)
+        # Add debug interface if the CPU has one ---------------------------------------------------
+        if hasattr(self.cpu, "debug_bus"):
+            self.register_mem(
+                name="vexriscv_debug",
+                address=0xf00f0000,
+                interface=self.cpu.debug_bus,
+                size=0x100)
 
-        # sdram
-        sdram_module = MT46H32M16(self.clk_freq, "1:2")
-        self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
-            platform.request("ddram"),
-            sdram_module.memtype,
-            rd_bitslip=2,
-            wr_bitslip=3,
-            dqs_ddr_alignment="C1"
-        )
+        # Memory mapped SPI Flash ------------------------------------------------------------------
+        # TODO: Add SPI Flash support here.
 
-        controller_settings = ControllerSettings(
-            with_bandwidth=True
-        )
+        # Support for soft-emulation for full Linux support ----------------------------------------
+        if self.cpu_type == "vexriscv" and self.cpu_variant == "linux":
+            size = 0x4000
+            self.submodules.emulator_ram = wishbone.SRAM(size)
+            self.register_mem("emulator_ram", self.mem_map["emulator_ram"], self.emulator_ram.bus, size)
 
-        self.register_sdram(self.ddrphy,
-            sdram_module.geom_settings,
-            sdram_module.timing_settings,
-            controller_settings=controller_settings
-        )
-
-        self.comb += [
-            self.ddrphy.clk4x_wr_strb.eq(self.crg.clk4x_wr_strb),
-            self.ddrphy.clk4x_rd_strb.eq(self.crg.clk4x_rd_strb),
-        ]
 
 SoC = BaseSoC

--- a/targets/saturn/crg.py
+++ b/targets/saturn/crg.py
@@ -1,0 +1,166 @@
+# Support for the Numato Saturn (http://numato.com/product/saturn-spartan-6-fpga-development-board-with-ddr-sdram)
+
+from fractions import Fraction
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+
+class _CRG(Module):
+    def __init__(self, platform, clk_freq):
+        # Clock domains for the system (soft CPU and related components run at).
+        self.clock_domains.cd_sys = ClockDomain()
+        # Clock domains for the DDR interface.
+        self.clock_domains.cd_sdram_half = ClockDomain()
+        self.clock_domains.cd_sdram_full_wr = ClockDomain()
+        self.clock_domains.cd_sdram_full_rd = ClockDomain()
+
+        # Input 100MHz clock
+        f0 = Fraction(100, 1)*1000000
+        clk100 = platform.request("clk100")
+        clk100a = Signal()
+        # Input 100MHz clock (buffered)
+        self.specials += Instance(
+            "IBUFG",
+            i_I=clk100,
+            o_O=clk100a
+        )
+
+        clk100b = Signal()
+
+        self.specials += Instance(
+            "BUFIO2",
+            p_DIVIDE=1,
+            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
+            i_I=clk100a,
+            o_DIVCLK=clk100b
+        )
+
+        #PLL parameters
+        f = Fraction(10, 1)
+        n, d = f.numerator, f.denominator
+        p = 8
+
+        assert f0*n/d/p/4 == clk_freq
+        assert 19e6     <= f0/d     <= 500e6    # pfd
+        assert 400e6    <= f0*n/d   <= 1000e6   # vco
+
+        # Unbuffered output signals from the PLL. They need to be buffered
+        # before feeding into the fabric.
+        unbuf_sdram_full    = Signal()
+        unbuf_sdram_half_a  = Signal()
+        unbuf_sdram_half_b  = Signal()
+        unbuf_unused_a      = Signal()
+        unbuf_unused_b      = Signal()
+        unbuf_sys           = Signal()
+
+        # PLL signals
+        pll_lckd = Signal()
+        pll_fb = Signal()
+        self.specials.pll = Instance(
+            "PLL_ADV",
+            name="crg_pll_adv",
+            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
+            p_REF_JITTER=.01,
+            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
+            p_DIVCLK_DIVIDE=d,
+            # Input Clocks (100MHz)
+            i_CLKIN1=clk100b,
+            p_CLKIN1_PERIOD=1e9/f0,
+            i_CLKIN2=0,
+            p_CLKIN2_PERIOD=0.,
+            i_CLKINSEL=1,
+            # Feedback
+            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
+            p_CLK_FEEDBACK="CLKFBOUT",
+            p_CLKFBOUT_MULT=n, p_CLKFBOUT_PHASE=0.,
+            # Outputs
+            # (125 MHz) sdram wr rd
+            o_CLKOUT0=unbuf_sdram_full,   p_CLKOUT0_DUTY_CYCLE=.5,
+            p_CLKOUT0_PHASE=0.,   p_CLKOUT0_DIVIDE=p,
+            # (125 MHz) unused
+            o_CLKOUT1=unbuf_unused_a,     p_CLKOUT1_DUTY_CYCLE=.5,
+            p_CLKOUT1_PHASE=0.,   p_CLKOUT1_DIVIDE=p,
+            # (62.5 MHz) sdram_half - sdram dqs adr ctrl
+            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
+            p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=(p*2),
+            # (62.5 MHz) off-chip ddr
+            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
+            p_CLKOUT3_PHASE=270., p_CLKOUT3_DIVIDE=(p*2),
+            # (31.25 MHz) unused
+            o_CLKOUT4=unbuf_unused_b,     p_CLKOUT4_DUTY_CYCLE=.5,
+            p_CLKOUT4_PHASE=0.,   p_CLKOUT4_DIVIDE=(p*4),
+            # (31.25 MHz) sysclk
+            o_CLKOUT5=unbuf_sys,          p_CLKOUT5_DUTY_CYCLE=.5,
+            p_CLKOUT5_PHASE=0.,   p_CLKOUT5_DIVIDE=(p*4),
+        )
+
+        #power on reset?
+        reset_pin = [("reset", 0, Pins("P2:0")), ]
+        platform.add_extension(reset_pin)
+        reset = platform.request("reset")
+        self.clock_domains.cd_por = ClockDomain()
+        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
+        self.sync.por += If(por != 0, por.eq(por - 1))
+        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
+
+        #System clock
+        self.specials += Instance("BUFG", i_I=unbuf_sys, o_O=self.cd_sys.clk)
+        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
+
+        # SDRAM clocks
+        # ------------------------------------------------------------------------------
+        self.clk4x_wr_strb = Signal()
+        self.clk4x_rd_strb = Signal()
+
+        # sdram_full
+        self.specials += Instance(
+            "BUFPLL",
+            p_DIVIDE=4,
+            i_PLLIN=unbuf_sdram_full,
+            i_GCLK=self.cd_sys.clk,
+            i_LOCKED=pll_lckd,
+            o_IOCLK=self.cd_sdram_full_wr.clk,
+            o_SERDESSTROBE=self.clk4x_wr_strb
+        )
+
+        self.comb += [
+            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
+            self.clk4x_rd_strb.eq(self.clk4x_wr_strb),
+        ]
+
+        # sdram_half
+        self.specials += Instance(
+            "BUFG",
+            i_I=unbuf_sdram_half_a,
+            o_O=self.cd_sdram_half.clk
+        )
+
+        clk_sdram_half_shifted = Signal()
+        self.specials += Instance(
+            "BUFG",
+            i_I=unbuf_sdram_half_b,
+            o_O=clk_sdram_half_shifted
+        )
+
+        clk = platform.request("ddram_clock")
+        self.specials += Instance(
+            "ODDR2",
+            p_DDR_ALIGNMENT="NONE",
+            p_INIT=0, p_SRTYPE="SYNC",
+            i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
+            i_C0=clk_sdram_half_shifted,
+            i_C1=~clk_sdram_half_shifted,
+            o_Q=clk.p
+        )
+
+        self.specials += Instance(
+            "ODDR2",
+            p_DDR_ALIGNMENT="NONE",
+            p_INIT=0, p_SRTYPE="SYNC",
+            i_D0=0, i_D1=1, i_S=0, i_R=0, i_CE=1,
+            i_C0=clk_sdram_half_shifted,
+            i_C1=~clk_sdram_half_shifted,
+            o_Q=clk.n
+        )

--- a/targets/sim/base.py
+++ b/targets/sim/base.py
@@ -13,19 +13,11 @@ from litedram.core.controller import ControllerSettings
 
 from gateware import firmware
 
-from targets.utils import csr_map_update
-
 
 class BaseSoC(SoCSDRAM):
-    csr_peripherals = (
-        ,
-    )
-    csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
-
-    mem_map = {
+    mem_map = {**SoCSDRAM, **{
         "firmware_ram": 0x20000000,  # (default shadow @0xa0000000)
-    }
-    mem_map.update(SoCSDRAM.mem_map)
+    }}
 
     def __init__(self, platform, **kwargs):
         if 'integrated_rom_size' not in kwargs:

--- a/targets/sim/memtest.py
+++ b/targets/sim/memtest.py
@@ -1,22 +1,16 @@
 from litedram.frontend.bist import LiteDRAMBISTGenerator, LiteDRAMBISTChecker
 
-from targets.utils import csr_map_update
 from targets.sim.net import NetSoC as BaseSoC
 
 
 class MemTestSoC(BaseSoC):
-    csr_peripherals = (
-        "generator",
-        "checker",
-    )
-    csr_map_update(BaseSoC.csr_map, csr_peripherals)
-
     def __init__(self, platform, *args, **kwargs):
         BaseSoC.__init__(self, platform, *args, **kwargs)
 
         self.submodules.generator = LiteDRAMBISTGenerator(
             self.sdram.crossbar.get_port(mode="write"),
         )
+        self.add_csr("generator")
         #self.submodules.checker = LiteDRAMBISTChecker(
         #    self.sdram.crossbar.get_port(mode="read", data_width=16),
         #    clock_domain="hdmi_out1_pix",
@@ -25,6 +19,7 @@ class MemTestSoC(BaseSoC):
             self.sdram.crossbar.get_port(mode="read"),
         #   cd="hdmi_out1_pix"),
         )
+        self.add_csr("checker")
 
 
 SoC = MemTestSoC

--- a/targets/sim/video.py
+++ b/targets/sim/video.py
@@ -3,7 +3,6 @@ from migen import *
 from litevideo.output.common import *
 from litevideo.output.core import VideoOutCore
 
-from targets.utils import csr_map_update
 from targets.sim.net import NetSoC as BaseSoC
 
 
@@ -22,14 +21,11 @@ class VGAModel(Module):
 
 
 class VideoSoC(BaseSoC):
-    csr_peripherals = {
-        "video_out": 20,
-    }
-    csr_map_update(BaseSoC.csr_map, csr_peripherals)
-
     def __init__(self, *args, **kwargs):
         BaseSoC.__init__(self, *args, **kwargs)
 
         self.submodules.video_out = VideoOutCore(self.sdram.crossbar.get_port())
+        # FIXME: The sim seems to require video_out CSR to be 20!?
+        self.add_csr("video_out", csr_id=20)
         self.submodules.vga = VGAModel(platform.request("vga"))
         self.comb += self.video_out.source.connect(self.vga.sink)

--- a/targets/tinyfpga_bx/base.py
+++ b/targets/tinyfpga_bx/base.py
@@ -54,10 +54,8 @@ class BaseSoC(SoCCore):
     }}
 
     def __init__(self, platform, **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x2800
+        kwargs['integrated_rom_size']=0
+        kwargs['integrated_sram_size']=0x2800
 
         # FIXME: Force either lite or minimal variants of CPUs; full is too big.
 

--- a/targets/tinyfpga_bx/internal.py
+++ b/targets/tinyfpga_bx/internal.py
@@ -121,10 +121,8 @@ class RAMSoC(SoCCore):
         #  - 8kbytes ROM - 16 x BRAMs
         #  - 4kbytes RAM -  8 x BRAMs
 
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=16*1024
+        kwargs['integrated_rom_size']=0
+        kwargs['integrated_sram_size']=16*1024
 
         # Disable BIOS
         #kwargs['integrated_rom_init'] = [0]

--- a/targets/tinyfpga_bx/internal.py
+++ b/targets/tinyfpga_bx/internal.py
@@ -6,11 +6,13 @@ import argparse
 from migen import *
 from migen.genlib.resetsync import AsyncResetSynchronizer
 
-from litex.build.generic_platform import Pins, Subsignal, IOStandard
+from litex.build.generic_platform import ConstraintError
+from litex.build.generic_platform import Pins, Subsignal, IOStandard, Misc
 from litex.soc.integration.soc_core import *
 from litex.soc.integration.builder import *
 
-from gateware import cas
+from gateware import info
+#from gateware import cas
 from gateware import spi_flash
 
 
@@ -22,12 +24,42 @@ serial =  [
     )
 ]
 
+reset_button =  [
+    # Reset shorts these two pins together
+    # Pin 12 - Silkscreen 12
+    ("reset", 0, Pins("GPIO:11"), IOStandard("LVCMOS33"), Misc("PullUp")),
+    # Pin 13 - Silkscreen 13
+    ("reset_out", 0, Pins("GPIO:12"), IOStandard("LVCMOS33")),
+]
+
+
 class _CRG(Module):
     def __init__(self, platform):
         clk16 = platform.request("clk16")
 
         self.clock_domains.cd_sys = ClockDomain()
+        self.clock_domains.cd_usb_48 = ClockDomain() #reset_less=True)
+
         self.reset = Signal()
+
+        # Reset signal goes high to reset.
+        try:
+            self.reset_pin = platform.request("reset")
+        except ConstraintError:
+            assert False
+            self.reset_pin = Signal()
+
+        # Drive reset_out a constant 1.
+        try:
+            reset_out = platform.request("reset_out")
+            self.comb += [
+                reset_out.eq(0),
+            ]
+        except ConstraintError:
+            assert False
+            pass
+
+        #self.platform.add_period_constraint(self.usb_48.clk, 1e9/48e9)
 
         # FIXME: Use PLL, increase system clock to 32 MHz, pending nextpnr
         # fixes.
@@ -39,7 +71,8 @@ class _CRG(Module):
         reset_delay = Signal(12, reset=4095)
         self.comb += [
             self.cd_por.clk.eq(self.cd_sys.clk),
-            self.cd_sys.rst.eq(reset_delay != 0)
+            self.cd_sys.rst.eq(reset_delay != 0),
+            platform.request("user_led").eq(self.reset_pin),
         ]
         self.sync.por += \
             If(reset_delay != 0,
@@ -47,40 +80,81 @@ class _CRG(Module):
             )
         self.specials += AsyncResetSynchronizer(self.cd_por, self.reset)
 
+        self.specials += [
+            Instance(
+                "SB_PLL40_CORE",
+                # Parameters
+                p_DIVR = 0,
+                p_DIVF = 0b0101111,
+                p_DIVQ = 0b100,
+                p_FILTER_RANGE = 1,
+                p_FEEDBACK_PATH = "SIMPLE",
+                p_DELAY_ADJUSTMENT_MODE_FEEDBACK = "FIXED",
+                p_FDA_FEEDBACK = 0,
+                p_DELAY_ADJUSTMENT_MODE_RELATIVE = "FIXED",
+                p_FDA_RELATIVE = 0,
+                p_SHIFTREG_DIV_MODE = 0,
+                p_PLLOUT_SELECT = "GENCLK",
+                p_ENABLE_ICEGATE = 0,
+                # IO
+                i_REFERENCECLK = clk16,
+                o_PLLOUTCORE = self.cd_usb_48.clk,
+                #o_PLLOUTGLOBAL,
+                #i_EXTFEEDBACK,
+                #i_DYNAMICDELAY,
+                #o_LOCK,
+                i_BYPASS = 0,
+                i_RESETB = 1,
+                #i_LATCHINPUTVALUE,
+                #o_SDO,
+                #i_SDI,
+            ),
+        ]
 
-class BaseSoC(SoCCore):
-    mem_map = {**SoCCore.mem_map, **{
-        "spiflash": 0x20000000,  # (default shadow @0xa0000000)
-    }}
 
+class RAMSoC(SoCCore):
     def __init__(self, platform, **kwargs):
+
+        # The TinyFPGA BX has 128kbit of blockram == 16kbytes
+        # Each BRAM is 512bytes == 32 BRAM blocks
+        # Need 4 BRAM blocks for USB, leaving 28.
+        #  - 8kbytes ROM - 16 x BRAMs
+        #  - 4kbytes RAM -  8 x BRAMs
+
         if 'integrated_rom_size' not in kwargs:
             kwargs['integrated_rom_size']=0
         if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x2800
+            kwargs['integrated_sram_size']=16*1024
+
+        # Disable BIOS
+        #kwargs['integrated_rom_init'] = [0]
 
         # FIXME: Force either lite or minimal variants of CPUs; full is too big.
+        if 'cpu_variant' not in kwargs:
+            kwargs['cpu_variant']='lite'
 
         platform.add_extension(serial)
+        platform.add_extension(reset_button)
         clk_freq = int(16e6)
 
         # Extra 0x28000 is due to bootloader bitstream.
-        kwargs['cpu_reset_address']=self.mem_map["spiflash"]+platform.gateware_size+platform.bootloader_size
         SoCCore.__init__(self, platform, clk_freq, **kwargs)
 
         self.submodules.crg = _CRG(platform)
         self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/clk_freq)
 
+        self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.add_csr("info")
+
         # Control and Status
-        self.submodules.cas = cas.ControlAndStatus(platform, clk_freq)
-        self.add_csr("cas")
+#        self.submodules.cas = cas.ControlAndStatus(platform, clk_freq)
+#        self.add_csr("cas")
 
         # SPI flash peripheral
         self.submodules.spiflash = spi_flash.SpiFlashSingle(
             platform.request("spiflash"),
             dummy=platform.spiflash_read_dummy_bits,
             div=platform.spiflash_clock_div)
-        self.add_csr("spiflash")
         self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
         self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
         self.register_mem("spiflash", self.mem_map["spiflash"],
@@ -88,23 +162,11 @@ class BaseSoC(SoCCore):
 
         bios_size = 0x8000
         self.add_constant("ROM_DISABLE", 1)
-        self.add_memory_region(
-            "rom", kwargs['cpu_reset_address'], bios_size,
-            type="cached+linker")
+        self.add_memory_region("rom", kwargs['cpu_reset_address'], bios_size)
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size+platform.bootloader_size
-        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
-
-        # We don't have a DRAM, so use the remaining SPI flash for user
-        # program.
-        self.add_memory_region("user_flash",
-            self.flash_boot_address,
-            # Leave a grace area- possible one-by-off bug in add_memory_region?
-            # Possible fix: addr < origin + length - 1
-            platform.spiflash_total_size - (self.flash_boot_address - self.mem_map["spiflash"]) - 0x100,
-            type="cached+linker")
 
         # Disable USB activity until we switch to a USB UART.
-        self.comb += [platform.request("usb").pullup.eq(0)]
+        #self.comb += [platform.request("usb").pullup.eq(0)]
 
         # Arachne-pnr is unsupported- it has trouble routing this design
         # on this particular board reliably. That said, annotate the build
@@ -114,4 +176,4 @@ class BaseSoC(SoCCore):
         platform.toolchain.build_template[3] = "icepack -s {build_name}.txt {build_name}.bin"
         platform.toolchain.nextpnr_build_template[2] = "icepack -s {build_name}.txt {build_name}.bin"
 
-SoC = BaseSoC
+SoC = RAMSoC

--- a/targets/upduino_v1/base.py
+++ b/targets/upduino_v1/base.py
@@ -15,7 +15,6 @@ from gateware import cas
 from gateware import ice40
 from gateware import spi_flash
 
-from targets.utils import csr_map_update
 import platforms.upduino_v1 as upduino
 
 
@@ -42,16 +41,9 @@ class _CRG(Module):
 
 
 class BaseSoC(SoCCore):
-    csr_peripherals = (
-        "spiflash",
-        "cas",
-    )
-    csr_map_update(SoCCore.csr_map, csr_peripherals)
-
-    mem_map = {
-        "spiflash": 0x20000000,  # (default shadow @0xa0000000)
-    }
-    mem_map.update(SoCCore.mem_map)
+    mem_map = {**SoCCore.mem_map, **{
+        "spiflash": 0x20000000,
+    }}
 
     def __init__(self, platform, **kwargs):
         if 'integrated_rom_size' not in kwargs:
@@ -73,12 +65,14 @@ class BaseSoC(SoCCore):
 
         # Control and Status
         self.submodules.cas = cas.ControlAndStatus(platform, clk_freq)
+        self.add_csr("cas")
 
         # SPI flash peripheral
         self.submodules.spiflash = spi_flash.SpiFlashSingle(
             platform.request("spiflash"),
             dummy=platform.spiflash_read_dummy_bits,
             div=platform.spiflash_clock_div, endianness=self.cpu.endianness)
+        self.add_csr("spiflash")
         self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
         self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
         self.register_mem("spiflash", self.mem_map["spiflash"],

--- a/targets/upduino_v1/base.py
+++ b/targets/upduino_v1/base.py
@@ -46,10 +46,8 @@ class BaseSoC(SoCCore):
     }}
 
     def __init__(self, platform, **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0
+        kwargs['integrated_rom_size']=0
+        kwargs['integrated_sram_size']=0
 
         # FIXME: Force either lite or minimal variants of CPUs; full is too big.
         platform.add_extension(upduino.serial)

--- a/targets/utils.py
+++ b/targets/utils.py
@@ -8,25 +8,6 @@ def period_ns(freq):
     return 1e9/freq
 
 
-def csr_map_update(csr_map, csr_peripherals):
-    csr_map.update(dict((n, v)
-        for v, n in enumerate(csr_peripherals, start=(max(csr_map.values()) + 1) if csr_map else 0)))
-
-
-def csr_map_update_print(csr_map, csr_peripherals):
-    print()
-    print("-"*75)
-    print("Previous Max: {}".format(max(csr_map.values())))
-    csr_map.update(dict((n, v)
-        for v, n in enumerate(csr_peripherals, start=max(csr_map.values()) + 1)))
-    print("     New Max: {}".format(max(csr_map.values())))
-    csr_values = list((b,a) for a, b in csr_map.items())
-    csr_values.sort()
-    pprint.pprint(csr_values)
-    print("-"*75)
-    print()
-
-
 def assert_pll_clock(requested_freq, input, feedback, divide, msg):
     output_freq = int(input * feedback / divide / 1e6)
     assert output_freq == int(requested_freq / 1e6), (

--- a/targets/utils.py
+++ b/targets/utils.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+
+import difflib
 import pprint
 
 
@@ -69,3 +72,85 @@ class MHzType(int):
 
 
 MHz = MHzType(1)
+
+
+test_build_template = [
+    "yosys -q -l {build_name}.rpt {build_name}.ys",
+    "nextpnr-ice40 --json {build_name}.json --pcf {build_name}.pcf",
+    "icepack {build_name}.txt {build_name}.bin"
+]
+
+
+def _platform_toolchain_cmd_split(template):
+    """
+
+    >>> cmds = _platform_toolchain_cmd_split(test_build_template)
+    >>> cmds["icepack"]
+    (2, ['icepack', '{build_name}.txt', '{build_name}.bin'])
+    >>> pprint.pprint(cmds["nextpnr-ice40"])
+    (1,
+     ['nextpnr-ice40', '--json', '{build_name}.json', '--pcf', '{build_name}.pcf'])
+    >>> cmds["yosys"]
+    (0, ['yosys', '-q', '-l', '{build_name}.rpt', '{build_name}.ys'])
+
+    """
+    cmds = {}
+    for i, cmdline in enumerate(template):
+        cmdline_parts = cmdline.split()
+        cmds[cmdline_parts[0]] = (i, list(cmdline_parts))
+    return cmds
+
+
+def _platform_toolchain_cmd_join(cmds):
+    """
+
+    >>> cmds = _platform_toolchain_cmd_split(test_build_template)
+    >>> out_template = _platform_toolchain_cmd_join(cmds)
+    >>> "\\n".join(difflib.context_diff("\\n".join(test_build_template), "\\n".join(out_template)))
+    ''
+    >>> pprint.pprint(out_template)
+    ['yosys -q -l {build_name}.rpt {build_name}.ys',
+     'nextpnr-ice40 --json {build_name}.json --pcf {build_name}.pcf',
+     'icepack {build_name}.txt {build_name}.bin']
+
+    """
+    template = []
+    while len(template) < len(cmds):
+        for i, cmdline_parts in cmds.values():
+            if i != len(template):
+                continue
+            template.append(" ".join(cmdline_parts))
+            break
+        else:
+            raise ValueError("{} not found\n{}\n{}\n".format(len(template), template, cmds))
+    return template
+
+
+def _add_switch(cmds, cmdname, argument):
+    """
+
+    >>> cmds = _platform_toolchain_cmd_split(test_build_template)
+    >>> _add_switch(cmds, 'icepack', '-s')
+    >>> out_template = _platform_toolchain_cmd_join(cmds)
+    >>> pprint.pprint(out_template)
+    ['yosys -q -l {build_name}.rpt {build_name}.ys',
+     'nextpnr-ice40 --json {build_name}.json --pcf {build_name}.pcf',
+     'icepack -s {build_name}.txt {build_name}.bin']
+
+    """
+    assert argument.startswith('-'), argument
+    assert cmdname in cmds, (cmdname, cmds)
+    cmds[cmdname][-1].insert(1, argument)
+
+
+def platform_toolchain_extend(platform, cmdname, argument):
+    bt = platform.toolchain.build_template
+    cmds = _platform_toolchain_cmd_split(bt)
+    _add_switch(cmds, cmdname, argument)
+    bt.clear()
+    bt.extend(_platform_toolchain_cmd_join(cmds))
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/targets/utils.py
+++ b/targets/utils.py
@@ -36,12 +36,14 @@ class MHzType(int):
     >>> a = MHzType(1)
     >>> a == int(1e9)
     True
-    >>> a
+    >>> print(a)
     1 MHz
     >>> b = 5 * MHzType(1)
     >>> b == int(5e9)
     True
     >>> b
+    5.000000 * MHz()
+    >>> print(b)
     5 MHz
     >>> c = 200 * MHzType(1)
     >>>

--- a/targets/waxwing/base.py
+++ b/targets/waxwing/base.py
@@ -1,226 +1,75 @@
 # Support for the Numato Saturn (http://numato.com/product/saturn-spartan-6-fpga-development-board-with-ddr-sdram)
-
-from fractions import Fraction
-
 from migen import *
-from migen.genlib.resetsync import AsyncResetSynchronizer
-
-from litex.build.generic_platform import *
 
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
+from litex.soc.interconnect import wishbone
 
 from litedram.modules import MT46H32M16
 from litedram.phy import s6ddrphy
 from litedram.core import ControllerSettings
 
-from targets.utils import csr_map_update
+#from gateware import cas
+from gateware import info
+from gateware import spi_flash
 
+from .crg import _CRG
 
-class _CRG(Module):
-    def __init__(self, platform, clk_freq):
-        # Clock domains for the system (soft CPU and related components run at).
-        self.clock_domains.cd_sys = ClockDomain()
-        # Clock domains for the DDR interface.
-        self.clock_domains.cd_sdram_half = ClockDomain()
-        self.clock_domains.cd_sdram_full_wr = ClockDomain()
-        self.clock_domains.cd_sdram_full_rd = ClockDomain()
-
-        # Input 100MHz clock
-        f0 = Fraction(100, 1)*1000000
-        clk100 = platform.request("clk100")
-        clk100a = Signal()
-        # Input 100MHz clock (buffered)
-        self.specials += Instance(
-            "IBUFG",
-            i_I=clk100,
-            o_O=clk100a
-        )
-
-        clk100b = Signal()
-
-        self.specials += Instance(
-            "BUFIO2",
-            p_DIVIDE=1,
-            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
-            i_I=clk100a,
-            o_DIVCLK=clk100b
-        )
-
-        #PLL parameters
-        f = Fraction(10, 1)
-        n, d = f.numerator, f.denominator
-        p = 8
-
-        assert f0*n/d/p/4 == clk_freq
-        assert 19e6     <= f0/d     <= 500e6    # pfd
-        assert 400e6    <= f0*n/d   <= 1000e6   # vco
-
-        # Unbuffered output signals from the PLL. They need to be buffered
-        # before feeding into the fabric.
-        unbuf_sdram_full    = Signal()
-        unbuf_sdram_half_a  = Signal()
-        unbuf_sdram_half_b  = Signal()
-        unbuf_unused_a      = Signal()
-        unbuf_unused_b      = Signal()
-        unbuf_sys           = Signal()
-
-        # PLL signals
-        pll_lckd = Signal()
-        pll_fb = Signal()
-        self.specials.pll = Instance(
-            "PLL_ADV",
-            name="crg_pll_adv",
-            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
-            p_REF_JITTER=.01,
-            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
-            p_DIVCLK_DIVIDE=d,
-            # Input Clocks (100MHz)
-            i_CLKIN1=clk100b,
-            p_CLKIN1_PERIOD=1e9/f0,
-            i_CLKIN2=0,
-            p_CLKIN2_PERIOD=0.,
-            i_CLKINSEL=1,
-            # Feedback
-            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
-            p_CLK_FEEDBACK="CLKFBOUT",
-            p_CLKFBOUT_MULT=n, p_CLKFBOUT_PHASE=0.,
-            # Outputs
-            # (125 MHz) sdram wr rd
-            o_CLKOUT0=unbuf_sdram_full,   p_CLKOUT0_DUTY_CYCLE=.5,
-            p_CLKOUT0_PHASE=0.,   p_CLKOUT0_DIVIDE=p,
-            # (125 MHz) unused
-            o_CLKOUT1=unbuf_unused_a,     p_CLKOUT1_DUTY_CYCLE=.5,
-            p_CLKOUT1_PHASE=0.,   p_CLKOUT1_DIVIDE=p,
-            # (62.5 MHz) sdram_half - sdram dqs adr ctrl
-            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
-            p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=(p*2),
-            # (62.5 MHz) off-chip ddr
-            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
-            p_CLKOUT3_PHASE=270., p_CLKOUT3_DIVIDE=(p*2),
-            # (31.25 MHz) unused
-            o_CLKOUT4=unbuf_unused_b,     p_CLKOUT4_DUTY_CYCLE=.5,
-            p_CLKOUT4_PHASE=0.,   p_CLKOUT4_DIVIDE=(p*4),
-            # (31.25 MHz) sysclk
-            o_CLKOUT5=unbuf_sys,          p_CLKOUT5_DUTY_CYCLE=.5,
-            p_CLKOUT5_PHASE=0.,   p_CLKOUT5_DIVIDE=(p*4),
-        )
-
-        #power on reset?
-        reset = ~platform.request("user_btn", 0)
-        self.clock_domains.cd_por = ClockDomain()
-        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
-        self.sync.por += If(por != 0, por.eq(por - 1))
-        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
-
-        #System clock
-        self.specials += Instance("BUFG", i_I=unbuf_sys, o_O=self.cd_sys.clk)
-        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
-        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
-
-        # SDRAM clocks
-        # ------------------------------------------------------------------------------
-        self.clk4x_wr_strb = Signal()
-        self.clk4x_rd_strb = Signal()
-
-        # sdram_full
-        self.specials += Instance(
-            "BUFPLL",
-            p_DIVIDE=4,
-            i_PLLIN=unbuf_sdram_full,
-            i_GCLK=self.cd_sys.clk,
-            i_LOCKED=pll_lckd,
-            o_IOCLK=self.cd_sdram_full_wr.clk,
-            o_SERDESSTROBE=self.clk4x_wr_strb
-        )
-
-        self.comb += [
-            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
-            self.clk4x_rd_strb.eq(self.clk4x_wr_strb),
-        ]
-
-        # sdram_half
-        self.specials += Instance(
-            "BUFG",
-            i_I=unbuf_sdram_half_a,
-            o_O=self.cd_sdram_half.clk
-        )
-
-        clk_sdram_half_shifted = Signal()
-        self.specials += Instance(
-            "BUFG",
-            i_I=unbuf_sdram_half_b,
-            o_O=clk_sdram_half_shifted
-        )
-
-        clk = platform.request("ddram_clock")
-        self.specials += Instance(
-            "ODDR2",
-            p_DDR_ALIGNMENT="NONE",
-            p_INIT=0, p_SRTYPE="SYNC",
-            i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
-            i_C0=clk_sdram_half_shifted,
-            i_C1=~clk_sdram_half_shifted,
-            o_Q=clk.p
-        )
-
-        self.specials += Instance(
-            "ODDR2",
-            p_DDR_ALIGNMENT="NONE",
-            p_INIT=0, p_SRTYPE="SYNC",
-            i_D0=0, i_D1=1, i_S=0, i_R=0, i_CE=1,
-            i_C0=clk_sdram_half_shifted,
-            i_C1=~clk_sdram_half_shifted,
-            o_Q=clk.n
-        )
 
 class BaseSoC(SoCSDRAM):
-    csr_peripherals = (
-        "ddrphy",
-    )
-    csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
-
-    # FIXME: Add spiflash
-    #mem_map = {
-    #    "spiflash": 0x20000000,  # (default shadow @0xa0000000)
-    #}
-    #mem_map.update(SoCSDRAM.mem_map)
+    mem_map = {**SoCSDRAM.mem_map, **{
+        spiflash=0x20000000,
+    }}
 
     def __init__(self, platform, **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0x8000
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x8000
+        kwargs['integrated_rom_size']=0x8000
+        kwargs['integrated_sram_size']=0x8000
 
-        clk_freq = (31 + Fraction(1, 4))*1000*1000
+        sys_clk_freq = (31 + Fraction(1, 4))*1000*1000
+        # SoCSDRAM ---------------------------------------------------------------------------------
+        SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq, **kwargs)
 
-        SoCSDRAM.__init__(self, platform, clk_freq, **kwargs)
-
+        # CRG --------------------------------------------------------------------------------------
         self.submodules.crg = _CRG(platform, clk_freq)
 
-        # sdram
-        sdram_module = MT46H32M16(self.clk_freq, "1:2")
-        self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
-            platform.request("ddram"),
-            sdram_module.memtype,
-            rd_bitslip=2,
-            wr_bitslip=3,
-            dqs_ddr_alignment="C1"
-        )
+        # DDR2 SDRAM -------------------------------------------------------------------------------
+        if True:
+            sdram_module = MT46H32M16(self.clk_freq, "1:2")
+            self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
+                platform.request("ddram"),
+                memtype      = sdram_module.memtype,
+                rd_bitslip   = 2,
+                wr_bitslip   = 3,
+                dqs_ddr_alignment="C1")
+            self.add_csr("ddrphy")
+            controller_settings = ControllerSettings(
+                with_bandwidth=True)
+            self.register_sdram(
+                self.ddrphy,
+                geom_settings   = sdram_module.geom_settings,
+                timing_settings = sdram_module.timing_settings,
+                controller_settings=controller_settings)
+            self.comb += [
+                self.ddrphy.clk4x_wr_strb.eq(self.crg.clk4x_wr_strb),
+                self.ddrphy.clk4x_rd_strb.eq(self.crg.clk4x_rd_strb),
+            ]
 
-        controller_settings = ControllerSettings(
-            with_bandwidth=True
-        )
+        # Basic peripherals ------------------------------------------------------------------------
+        # info module
+        self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.add_csr("info")
+        # control and status module
+        #self.submodules.cas = cas.ControlAndStatus(platform, sys_clk_freq)
+        self.add_csr("cas")
 
-        self.register_sdram(self.ddrphy,
-            sdram_module.geom_settings,
-            sdram_module.timing_settings,
-            controller_settings=controller_settings
-        )
+        # Add debug interface if the CPU has one ---------------------------------------------------
+        if hasattr(self.cpu, "debug_bus"):
+            self.register_mem(
+                name="vexriscv_debug",
+                address=0xf00f0000,
+                interface=self.cpu.debug_bus,
+                size=0x100)
 
-        self.comb += [
-            self.ddrphy.clk4x_wr_strb.eq(self.crg.clk4x_wr_strb),
-            self.ddrphy.clk4x_rd_strb.eq(self.crg.clk4x_rd_strb),
-        ]
-
+        # Memory mapped SPI Flash ------------------------------------------------------------------
+        # TODO: Add SPI flash.
 SoC = BaseSoC

--- a/targets/waxwing/base.py
+++ b/targets/waxwing/base.py
@@ -1,4 +1,7 @@
 # Support for the Numato Saturn (http://numato.com/product/saturn-spartan-6-fpga-development-board-with-ddr-sdram)
+
+from fractions import Fraction
+
 from migen import *
 
 from litex.soc.integration.soc_sdram import *
@@ -18,7 +21,7 @@ from .crg import _CRG
 
 class BaseSoC(SoCSDRAM):
     mem_map = {**SoCSDRAM.mem_map, **{
-        spiflash=0x20000000,
+        'spiflash': 0x20000000,
     }}
 
     def __init__(self, platform, **kwargs):
@@ -30,11 +33,12 @@ class BaseSoC(SoCSDRAM):
         SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq, **kwargs)
 
         # CRG --------------------------------------------------------------------------------------
-        self.submodules.crg = _CRG(platform, clk_freq)
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/sys_clk_freq)
 
         # DDR2 SDRAM -------------------------------------------------------------------------------
         if True:
-            sdram_module = MT46H32M16(self.clk_freq, "1:2")
+            sdram_module = MT46H32M16(sys_clk_freq, "1:2")
             self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
                 platform.request("ddram"),
                 memtype      = sdram_module.memtype,

--- a/targets/waxwing/crg.py
+++ b/targets/waxwing/crg.py
@@ -1,0 +1,164 @@
+# Support for the Numato Saturn (http://numato.com/product/saturn-spartan-6-fpga-development-board-with-ddr-sdram)
+
+from fractions import Fraction
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+
+class _CRG(Module):
+    def __init__(self, platform, clk_freq):
+        # Clock domains for the system (soft CPU and related components run at).
+        self.clock_domains.cd_sys = ClockDomain()
+        # Clock domains for the DDR interface.
+        self.clock_domains.cd_sdram_half = ClockDomain()
+        self.clock_domains.cd_sdram_full_wr = ClockDomain()
+        self.clock_domains.cd_sdram_full_rd = ClockDomain()
+
+        # Input 100MHz clock
+        f0 = Fraction(100, 1)*1000000
+        clk100 = platform.request("clk100")
+        clk100a = Signal()
+        # Input 100MHz clock (buffered)
+        self.specials += Instance(
+            "IBUFG",
+            i_I=clk100,
+            o_O=clk100a
+        )
+
+        clk100b = Signal()
+
+        self.specials += Instance(
+            "BUFIO2",
+            p_DIVIDE=1,
+            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
+            i_I=clk100a,
+            o_DIVCLK=clk100b
+        )
+
+        #PLL parameters
+        f = Fraction(10, 1)
+        n, d = f.numerator, f.denominator
+        p = 8
+
+        assert f0*n/d/p/4 == clk_freq
+        assert 19e6     <= f0/d     <= 500e6    # pfd
+        assert 400e6    <= f0*n/d   <= 1000e6   # vco
+
+        # Unbuffered output signals from the PLL. They need to be buffered
+        # before feeding into the fabric.
+        unbuf_sdram_full    = Signal()
+        unbuf_sdram_half_a  = Signal()
+        unbuf_sdram_half_b  = Signal()
+        unbuf_unused_a      = Signal()
+        unbuf_unused_b      = Signal()
+        unbuf_sys           = Signal()
+
+        # PLL signals
+        pll_lckd = Signal()
+        pll_fb = Signal()
+        self.specials.pll = Instance(
+            "PLL_ADV",
+            name="crg_pll_adv",
+            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
+            p_REF_JITTER=.01,
+            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
+            p_DIVCLK_DIVIDE=d,
+            # Input Clocks (100MHz)
+            i_CLKIN1=clk100b,
+            p_CLKIN1_PERIOD=1e9/f0,
+            i_CLKIN2=0,
+            p_CLKIN2_PERIOD=0.,
+            i_CLKINSEL=1,
+            # Feedback
+            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
+            p_CLK_FEEDBACK="CLKFBOUT",
+            p_CLKFBOUT_MULT=n, p_CLKFBOUT_PHASE=0.,
+            # Outputs
+            # (125 MHz) sdram wr rd
+            o_CLKOUT0=unbuf_sdram_full,   p_CLKOUT0_DUTY_CYCLE=.5,
+            p_CLKOUT0_PHASE=0.,   p_CLKOUT0_DIVIDE=p,
+            # (125 MHz) unused
+            o_CLKOUT1=unbuf_unused_a,     p_CLKOUT1_DUTY_CYCLE=.5,
+            p_CLKOUT1_PHASE=0.,   p_CLKOUT1_DIVIDE=p,
+            # (62.5 MHz) sdram_half - sdram dqs adr ctrl
+            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
+            p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=(p*2),
+            # (62.5 MHz) off-chip ddr
+            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
+            p_CLKOUT3_PHASE=270., p_CLKOUT3_DIVIDE=(p*2),
+            # (31.25 MHz) unused
+            o_CLKOUT4=unbuf_unused_b,     p_CLKOUT4_DUTY_CYCLE=.5,
+            p_CLKOUT4_PHASE=0.,   p_CLKOUT4_DIVIDE=(p*4),
+            # (31.25 MHz) sysclk
+            o_CLKOUT5=unbuf_sys,          p_CLKOUT5_DUTY_CYCLE=.5,
+            p_CLKOUT5_PHASE=0.,   p_CLKOUT5_DIVIDE=(p*4),
+        )
+
+        #power on reset?
+        reset = ~platform.request("user_btn", 0)
+        self.clock_domains.cd_por = ClockDomain()
+        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
+        self.sync.por += If(por != 0, por.eq(por - 1))
+        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
+
+        #System clock
+        self.specials += Instance("BUFG", i_I=unbuf_sys, o_O=self.cd_sys.clk)
+        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
+
+        # SDRAM clocks
+        # ------------------------------------------------------------------------------
+        self.clk4x_wr_strb = Signal()
+        self.clk4x_rd_strb = Signal()
+
+        # sdram_full
+        self.specials += Instance(
+            "BUFPLL",
+            p_DIVIDE=4,
+            i_PLLIN=unbuf_sdram_full,
+            i_GCLK=self.cd_sys.clk,
+            i_LOCKED=pll_lckd,
+            o_IOCLK=self.cd_sdram_full_wr.clk,
+            o_SERDESSTROBE=self.clk4x_wr_strb
+        )
+
+        self.comb += [
+            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
+            self.clk4x_rd_strb.eq(self.clk4x_wr_strb),
+        ]
+
+        # sdram_half
+        self.specials += Instance(
+            "BUFG",
+            i_I=unbuf_sdram_half_a,
+            o_O=self.cd_sdram_half.clk
+        )
+
+        clk_sdram_half_shifted = Signal()
+        self.specials += Instance(
+            "BUFG",
+            i_I=unbuf_sdram_half_b,
+            o_O=clk_sdram_half_shifted
+        )
+
+        clk = platform.request("ddram_clock")
+        self.specials += Instance(
+            "ODDR2",
+            p_DDR_ALIGNMENT="NONE",
+            p_INIT=0, p_SRTYPE="SYNC",
+            i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
+            i_C0=clk_sdram_half_shifted,
+            i_C1=~clk_sdram_half_shifted,
+            o_Q=clk.p
+        )
+
+        self.specials += Instance(
+            "ODDR2",
+            p_DDR_ALIGNMENT="NONE",
+            p_INIT=0, p_SRTYPE="SYNC",
+            i_D0=0, i_D1=1, i_S=0, i_R=0, i_CE=1,
+            i_C0=clk_sdram_half_shifted,
+            i_C1=~clk_sdram_half_shifted,
+            o_Q=clk.n
+        )

--- a/targets/waxwing/net.py
+++ b/targets/waxwing/net.py
@@ -35,10 +35,8 @@ class BaseSoC(SoCSDRAM):
     }}
 
     def __init__(self, platform, **kwargs):
-        if 'integrated_rom_size' not in kwargs:
-            kwargs['integrated_rom_size']=0x8000
-        if 'integrated_sram_size' not in kwargs:
-            kwargs['integrated_sram_size']=0x8000
+        kwargs['integrated_rom_size']=0x8000
+        kwargs['integrated_sram_size']=0x8000
 
         clk_freq = (31 + Fraction(1, 4))*1000*1000
         SoCSDRAM.__init__(self, platform, clk_freq, **kwargs)

--- a/targets/waxwing/net.py
+++ b/targets/waxwing/net.py
@@ -24,180 +24,15 @@ from liteeth.mac import LiteEthMAC
 
 from litex.soc.interconnect import wishbone
 
-# CRG ----------------------------------------------------------------------------------------------
+from .crg import _CRG
 
-class _CRG(Module):
-    def __init__(self, platform, clk_freq):
-        # Clock domains for the system (soft CPU and related components run at).
-        self.clock_domains.cd_sys = ClockDomain()
-        # Clock domains for the DDR interface.
-        self.clock_domains.cd_sdram_half = ClockDomain()
-        self.clock_domains.cd_sdram_full_wr = ClockDomain()
-        self.clock_domains.cd_sdram_full_rd = ClockDomain()
-        self.clock_domains.cd_eth = ClockDomain()
-
-        # Input 100MHz clock
-        f0 = Fraction(100, 1)*1000000
-        clk100 = platform.request("clk100")
-        clk100a = Signal()
-        # Input 100MHz clock (buffered)
-        self.specials += Instance(
-            "IBUFG",
-            i_I=clk100,
-            o_O=clk100a
-        )
-
-        clk100b = Signal()
-
-        self.specials += Instance(
-            "BUFIO2",
-            p_DIVIDE=1,
-            p_DIVIDE_BYPASS="TRUE", p_I_INVERT="FALSE",
-            i_I=clk100a,
-            o_DIVCLK=clk100b
-        )
-
-        #PLL parameters
-        f = Fraction(10, 1)
-        n, d = f.numerator, f.denominator
-        p = 8
-
-        assert f0*n/d/p/4 == clk_freq
-        assert 19e6     <= f0/d     <= 500e6    # pfd
-        assert 400e6    <= f0*n/d   <= 1000e6   # vco
-
-        # Unbuffered output signals from the PLL. They need to be buffered
-        # before feeding into the fabric.
-        unbuf_sdram_full    = Signal()
-        unbuf_sdram_half_a  = Signal()
-        unbuf_sdram_half_b  = Signal()
-        unbuf_unused_a      = Signal()
-        unbuf_eth           = Signal()
-        unbuf_sys           = Signal()
-
-        # PLL signals
-        pll_lckd = Signal()
-        pll_fb = Signal()
-        self.specials.pll = Instance(
-            "PLL_ADV",
-            name="crg_pll_adv",
-            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
-            p_REF_JITTER=.01,
-            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
-            p_DIVCLK_DIVIDE=d,
-            # Input Clocks (100MHz)
-            i_CLKIN1=clk100b,
-            p_CLKIN1_PERIOD=1e9/f0,
-            i_CLKIN2=0,
-            p_CLKIN2_PERIOD=0.,
-            i_CLKINSEL=1,
-            # Feedback
-            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
-            p_CLK_FEEDBACK="CLKFBOUT",
-            p_CLKFBOUT_MULT=n, p_CLKFBOUT_PHASE=0.,
-            # Outputs
-            # (125 MHz) sdram wr rd
-            o_CLKOUT0=unbuf_sdram_full,   p_CLKOUT0_DUTY_CYCLE=.5,
-            p_CLKOUT0_PHASE=0.,   p_CLKOUT0_DIVIDE=p,
-            # (125 MHz) unused
-            o_CLKOUT1=unbuf_unused_a,     p_CLKOUT1_DUTY_CYCLE=.5,
-            p_CLKOUT1_PHASE=0.,   p_CLKOUT1_DIVIDE=p,
-            # (62.5 MHz) sdram_half - sdram dqs adr ctrl
-            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
-            p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=(p*2),
-            # (62.5 MHz) off-chip ddr
-            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
-            p_CLKOUT3_PHASE=270., p_CLKOUT3_DIVIDE=(p*2),
-            # (25.00 MHz) eth
-            o_CLKOUT4=unbuf_eth,  p_CLKOUT4_DUTY_CYCLE=.5,
-            p_CLKOUT4_PHASE=0.,   p_CLKOUT4_DIVIDE=(p*5),
-            # (31.25 MHz) sysclk
-            o_CLKOUT5=unbuf_sys,          p_CLKOUT5_DUTY_CYCLE=.5,
-            p_CLKOUT5_PHASE=0.,   p_CLKOUT5_DIVIDE=(p*4),
-        )
-
-        #power on reset?
-        reset = ~platform.request("user_btn", 0)
-        self.clock_domains.cd_por = ClockDomain()
-        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
-        self.sync.por += If(por != 0, por.eq(por - 1))
-        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
-
-        #System clock
-        self.specials += Instance("BUFG", i_I=unbuf_sys, o_O=self.cd_sys.clk)
-        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
-        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
-
-        # SDRAM clocks
-        # ------------------------------------------------------------------------------
-        self.clk4x_wr_strb = Signal()
-        self.clk4x_rd_strb = Signal()
-
-        # sdram_full
-        self.specials += Instance(
-            "BUFPLL",
-            p_DIVIDE=4,
-            i_PLLIN=unbuf_sdram_full,
-            i_GCLK=self.cd_sys.clk,
-            i_LOCKED=pll_lckd,
-            o_IOCLK=self.cd_sdram_full_wr.clk,
-            o_SERDESSTROBE=self.clk4x_wr_strb
-        )
-
-        self.comb += [
-            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
-            self.clk4x_rd_strb.eq(self.clk4x_wr_strb),
-        ]
-
-        # ethernet
-        self.specials += Instance(
-            "BUFG",
-            i_I=unbuf_eth,
-            o_O=self.cd_eth.clk
-        )
-
-        # sdram_half
-        self.specials += Instance(
-            "BUFG",
-            i_I=unbuf_sdram_half_a,
-            o_O=self.cd_sdram_half.clk
-        )
-
-        clk_sdram_half_shifted = Signal()
-        self.specials += Instance(
-            "BUFG",
-            i_I=unbuf_sdram_half_b,
-            o_O=clk_sdram_half_shifted
-        )
-
-        clk = platform.request("ddram_clock")
-        self.specials += Instance(
-            "ODDR2",
-            p_DDR_ALIGNMENT="NONE",
-            p_INIT=0, p_SRTYPE="SYNC",
-            i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
-            i_C0=clk_sdram_half_shifted,
-            i_C1=~clk_sdram_half_shifted,
-            o_Q=clk.p
-        )
-
-        self.specials += Instance(
-            "ODDR2",
-            p_DDR_ALIGNMENT="NONE",
-            p_INIT=0, p_SRTYPE="SYNC",
-            i_D0=0, i_D1=1, i_S=0, i_R=0, i_CE=1,
-            i_C0=clk_sdram_half_shifted,
-            i_C1=~clk_sdram_half_shifted,
-            o_Q=clk.n
-        )
 
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCSDRAM):
-    mem_map = {
+    mem_map = {**SoCSDRAM.mem_map, **{
         "emulator_ram": 0x50000000,  # (default shadow @0xd0000000)
-    }
-    mem_map.update(SoCSDRAM.mem_map)
+    }}
 
     def __init__(self, platform, **kwargs):
         if 'integrated_rom_size' not in kwargs:
@@ -216,7 +51,7 @@ class BaseSoC(SoCSDRAM):
             self.register_mem("emulator_ram", self.mem_map["emulator_ram"], self.emulator_ram.bus, size)
 
         # sdram
-        if not self.integrated_main_ram_size:        
+        if not self.integrated_main_ram_size:
             sdram_module = MT46H32M16(clk_freq, "1:2")
             self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
                 platform.request("ddram"),

--- a/test/ipython_etherbone.py
+++ b/test/ipython_etherbone.py
@@ -5,14 +5,14 @@ from IPython import embed
 from litescope.software.driver.analyzer import LiteScopeAnalyzerDriver
 
 from common import *
-
+from make import get_testdir
 
 def main():
     args, wb = connect("LiteX Etherbone Interactive Console")
     print_memmap(wb)
     print()
 
-    analyzer_csv = '{}/analyzer.csv'.format(make_testdir(args))
+    analyzer_csv = '{}/analyzer.csv'.format(get_testdir(args))
     if os.path.exists(analyzer_csv):
         analyzer = LiteScopeAnalyzerDriver(wb.regs, "analyzer", config_csv=analyzer_csv, debug=True)
     else:


### PR DESCRIPTION
LiteX has change a lot since LiteX-BuildEnv was created. This pull request attempts to move towards more unification with upstream.

The major changes are;
 * Use new way to update `mem_map`.
 * Use `add_csr` + `add_interrupt` rather than previous dictionaries.
 * Use `add_wb_slave` + `add_memory_region` (cleanup usage of shadow_base and similar).

TODO Items;
 - [ ] Replace the `CRG` with new `S7PLL` and similar primitives (see https://github.com/litex-hub/litex-boards/blob/2ec6bc0bdc21b0c8afd9ca1fef0579f046c78fee/litex_boards/community/targets/mimas_a7.py#L26-L43)
 - [ ] Replace the `platforms` directory with importing from [`litex-boards`](https://github.com/litex-hub/litex-boards) and extending with the extra info.
 - [ ] Move a bunch of stuff into common functions (IE `add_spiflash`, `add_debug`, `add_linux`, etc)
 - [ ] Other stuff?
