### PR TITLE
WIP: Fix the iCE40HX8K targets

### DIFF
--- a/make.py
+++ b/make.py
@@ -69,7 +69,7 @@ def get_prog(args, platform):
 
 def get_image(builddir, filetype):
     assert filetype == "flash"
-    return os.path.join(builddir, "image.bin")
+    return os.path.join(builddir, "image-gateware+bios+firmware.bin")
 
 
 def get_gateware(builddir, filetype):


### PR DESCRIPTION
This pull request should fix the targets which use the iCE40HX8K including;
 - `ice40hx8k-b-evn` board
 - `tinyfpga-bx` board

Before this is merged the following should be tested;
 - [ ] `ice40hx8k-b-evn` board boots `stub` firmware with `lm32` CPU
 - [ ] `ice40hx8k-b-evn` board boots `stub` firmware with `vexriscv` CPU
 - [ ] `ice40hx8k-b-evn` board boots `micropython` firmware with `lm32` CPU
 - [ ] `ice40hx8k-b-evn` board boots `micropython` firmware with `vexriscv` CPU
 - [ ] `ice40hx8k-b-evn` board boots `zephyr` firmware with `vexriscv` CPU

 - [ ] `tinyfpga-bx` board boots `stub` firmware with `lm32` CPU
 - [ ] `tinyfpga-bx` board boots `stub` firmware with `vexriscv` CPU
 - [ ] `tinyfpga-bx` board boots `micropython` firmware with `lm32` CPU
 - [ ] `tinyfpga-bx` board boots `micropython` firmware with `vexriscv` CPU
