### PR TITLE
MATRIX Voice supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ env:
    - C=lm32             TC="vivado"    P=nexys_video       T="base net"
    - C=lm32             TC="ise"       P=atlys             T="base net"
    - C=lm32             TC="ise"       P=galatea           T="base"
+   - C=lm32             TC="ise"       P=matrix_voice      T="base"
    - C=lm32             TC="ise"       P=mimasv2           T="base"
    - C=lm32             TC="ise"       P=minispartan6      T="base"
    - C=lm32             TC="ise"       P=opsis             T="base net"
@@ -94,6 +95,7 @@ env:
    - C=vexriscv.lite    TC="icestorm"  P=upduino_v1        T="base"       F=stub
    - C=vexriscv.lite    TC="icestorm"  P=icefun            T="base"       F=stub
    - C=vexriscv.lite    TC="vivado"    P=arty              T="base net"
+   - C=vexriscv.lite    TC="ise"       P=matrix_voice      T="base"
    - C=vexriscv.lite    TC="ise"       P=opsis             T="base net"
    - C=vexriscv.lite    TC="ise"       P=pano_logic_g2     T="base"
    # PicoRV32
@@ -102,6 +104,7 @@ env:
    - C=picorv32         TC="ise"       P=opsis             T="base net"
    - C=picorv32.minimal TC="icestorm"  P=icebreaker        T="base"       F=stub
    - C=picorv32.minimal TC="vivado"    P=arty              T="base net"
+   - C=picorv32.minimal TC="ise"       P=matrix_voice      T="base"
    - C=picorv32.minimal TC="ise"       P=opsis             T="base net"
    # minerva target
    - C=minerva          TC="vivado"    P=arty              T="base net"

--- a/platforms/matrix_voice.py
+++ b/platforms/matrix_voice.py
@@ -1,0 +1,96 @@
+# Support for the MATRIX Voice
+# https://www.matrix.one/products/voice
+# Author: Andres Calderon <andres.calderon@admobilize.com>
+# FPGA: Spartan 6 xc6slx9-2-ftg256
+# Copyright 2020 MATRIX Labs
+# License: BSD
+
+from litex.build.generic_platform import *
+from litex.build.xilinx import XilinxPlatform
+
+_io = [
+    ("clk50", 0, Pins("T7"), IOStandard("LVCMOS33")),
+#   RPI_GPIO26
+    ("cpu_reset", 0, Pins("N6"), IOStandard("LVCMOS33"), Misc("PULLUP")),
+
+    ("serial", 0,
+        Subsignal("tx", Pins("B12"), IOStandard("LVCMOS33"),
+                  Misc("SLEW=FAST")),
+        Subsignal("rx", Pins("A12"), IOStandard("LVCMOS33"),
+                  Misc("SLEW=FAST"))),
+
+    ("spiflash", 0,
+        Subsignal("cs_n", Pins("T3")),
+        Subsignal("clk", Pins("R11")),
+        Subsignal("mosi", Pins("T10")),
+        Subsignal("miso", Pins("P10"), Misc("PULLUP")),
+        IOStandard("LVCMOS33"), Misc("SLEW=FAST")),
+
+    ("ddram_clock", 0,
+        Subsignal("p", Pins("G12")),
+        Subsignal("n", Pins("H11")),
+        IOStandard("DIFF_SSTL18_II"), Misc("IN_TERM=NONE")),
+
+    ("ddram", 0,
+        Subsignal(
+            "a", 
+#                   0   1   2   3   4   5   6   7   8   9  10  11  12 
+            Pins("H15 H16 F16 H13 C16 J11 J12 F15 F13 F14 C15 G11 D16"), 
+            IOStandard("SSTL18_II")
+        ),
+        Subsignal("ba", Pins("G14 G16"), IOStandard("SSTL18_II")),
+        Subsignal("cke", Pins("D14"), IOStandard("SSTL18_II")),
+        Subsignal("ras_n", Pins("J13"), IOStandard("SSTL18_II")),
+        Subsignal("cas_n", Pins("K14"), IOStandard("SSTL18_II")),
+        Subsignal("we_n", Pins("E15"), IOStandard("SSTL18_II")),
+        Subsignal(
+            "dq", 
+#                   0   1   2   3   4   5   6   7   8   9   10   11   12   13   14   15  
+            Pins("L14 L16 M15 M16 J14 J16 K15 K16 P15 P16  R15  R16  T14  T13  R12  T12"),
+            IOStandard("SSTL18_II")
+        ),
+        Subsignal("dqs", Pins("R14 N14"), IOStandard("DIFF_SSTL18_II")),
+        Subsignal("dqs_n", Pins("T15 N16"), IOStandard("DIFF_SSTL18_II")),
+        Subsignal("dm", Pins("K12 K11"), IOStandard("SSTL18_II")),
+        Subsignal("odt", Pins("H14"), IOStandard("SSTL18_II"))
+    ),
+
+    # LED
+    ("user_led", 0, Pins("T5"), IOStandard("LVCMOS33"), Drive(8)),
+]
+
+_connectors = [
+    ("P2", "G1 G3 H1 H2 J1 J3 K1 K2 L1 M1 M2 N1 P1 P2 R1 R2"),
+]
+
+class Platform(XilinxPlatform):
+    name = "matrix_voice"
+    default_clk_name = "clk50"
+    default_clk_period = 20
+
+    gateware_size = 0x180000
+
+    spiflash_model = "25l6405"
+    spiflash_read_dummy_bits = 4
+    spiflash_clock_div = 4
+    spiflash_total_size = int((64/8)*1024*1024) # 64Mbit
+    spiflash_page_size = 256
+    spiflash_sector_size = 0x10000
+
+    def __init__(self, device="xc6slx9", programmer="xc3sprog"):
+        XilinxPlatform.__init__(self, device+"-2-ftg256", _io, _connectors)
+        self.programmer = programmer
+
+    def create_programmer(self):
+        proxy="bscan_spi_{}.bit".format(self.device.split('-')[0])
+        if self.programmer == "xc3sprog":
+            return XC3SProg("matrix_voice", proxy)
+        else:
+            raise ValueError("{} programmer is not supported".format(self.programmer))
+
+    def do_finalize(self, fragment):
+        XilinxPlatform.do_finalize(self, fragment)
+        try:
+            self.add_period_constraint(self.lookup_request("clk50", 0), 20)
+        except ConstraintError:
+            pass

--- a/targets/matrix_voice/Makefile.mk
+++ b/targets/matrix_voice/Makefile.mk
@@ -1,0 +1,49 @@
+# matrix_voice targets
+
+ifneq ($(PLATFORM),matrix_voice)
+	$(error "Platform should be matrix_voice when using this file!?")
+endif
+
+# Settings
+DEFAULT_TARGET = base
+TARGET ?= $(DEFAULT_TARGET)
+
+# Image
+image-flash-$(PLATFORM):
+	@echo "MATRIX Voice doesn't support just flashing firmware from PC, try xc3sprog running in the Raspberry instead."
+
+# Gateware
+gateware-load-$(PLATFORM):
+	@echo "MATRIX Voice doesn't support just flashing firmware from PC, try xc3sprog running in the Raspberry instead."
+	@false
+
+gateware-flash-$(PLATFORM): $(GATEWARE_BIOS_FILE)
+	@echo "MATRIX Voice doesn't support just flashing firmware from PC, try xc3sprog running in the Raspberry instead."
+	@false
+
+firmware-load-$(PLATFORM):
+	@echo "MATRIX Voice doesn't support firmware load from PC, try flterm running in the Raspberry instead."
+	@false
+
+firmware-flash-$(PLATFORM):
+	@echo "MATRIX Voice doesn't support flashing firmware from PC, try flterm running in the Raspberry instead."
+	@false
+
+firmware-connect-$(PLATFORM):
+	@echo "MATRIX Voice doesn't support connect from PC, try flterm running in the Raspberry instead."
+
+firmware-clear-$(PLATFORM):
+	@echo "Unsupported."
+	@false
+
+bios-flash-$(PLATFORM):
+	@echo "Unsupported."
+	@false
+
+help-$(PLATFORM):
+	@true
+
+reset-$(PLATFORM):
+	@echo "Unsupported."
+	@false
+

--- a/targets/matrix_voice/base.py
+++ b/targets/matrix_voice/base.py
@@ -1,0 +1,228 @@
+# Support for the MATRIX Voice
+# https://www.matrix.one/products/voice
+# Author: Andres Calderon <andres.calderon@admobilize.com>
+# FPGA: Spartan 6 xc6slx9-2-ftg256
+# Copyright 2020 MATRIX Labs
+# License: BSD
+
+from fractions import Fraction
+
+from migen import *
+from migen.genlib.resetsync import AsyncResetSynchronizer
+from migen.genlib.misc import WaitTimer
+
+from litex.soc.integration.soc_sdram import *
+from litex.soc.integration.builder import *
+
+from litedram.modules import MT47H32M16
+from litedram.phy import s6ddrphy
+from litedram.core import ControllerSettings
+
+from gateware import cas
+from gateware import info
+from gateware import spi_flash
+
+from targets.utils import csr_map_update
+
+
+class _CRG(Module):
+    def __init__(self, platform, clk_freq):
+        # Clock domains for the system (soft CPU and related components run at).
+        self.clock_domains.cd_sys = ClockDomain()
+        # Clock domains for the DDR interface.
+        self.clock_domains.cd_sdram_half = ClockDomain()
+        self.clock_domains.cd_sdram_full_wr = ClockDomain()
+        self.clock_domains.cd_sdram_full_rd = ClockDomain()
+        # Clock domain for peripherals (such as HDMI output).
+        self.clock_domains.cd_base50 = ClockDomain()
+        self.clock_domains.cd_encoder = ClockDomain()
+
+        self.reset = Signal()
+
+        # Input 50MHz clock
+        f0 = 50*1000*1000
+        clk50 = platform.request("clk50")
+        clk50a = Signal()
+        # Input 50MHz clock (buffered)
+        self.specials += Instance(
+            "IBUFG", 
+            i_I=clk50, 
+            o_O=clk50a
+        )
+        clk50b = Signal()
+        self.specials += Instance(
+            "BUFIO2", 
+            p_DIVIDE=1,
+            p_DIVIDE_BYPASS="TRUE", 
+            p_I_INVERT="FALSE",
+            i_I=clk50a, 
+            o_DIVCLK=clk50b
+        )
+
+        # Unbuffered output signals from the PLL. They need to be buffered
+        # before feeding into the fabric.
+        unbuf_sdram_full = Signal()
+        unbuf_sdram_half_a = Signal()
+        unbuf_sdram_half_b = Signal()
+        unbuf_unused = Signal()
+        unbuf_sys = Signal()
+        unbuf_periph = Signal()
+
+        # PLL signals
+        pll_lckd = Signal()
+        pll_fb = Signal()
+        self.specials.pll = Instance(
+            "PLL_ADV",
+            name="crg_pll_adv",
+            p_SIM_DEVICE="SPARTAN6", p_BANDWIDTH="OPTIMIZED", p_COMPENSATION="INTERNAL",
+            p_REF_JITTER=.01,
+            i_DADDR=0, i_DCLK=0, i_DEN=0, i_DI=0, i_DWE=0, i_RST=0, i_REL=0,
+            p_DIVCLK_DIVIDE=1,
+            # Input Clocks (50MHz)
+            i_CLKIN1=clk50b,
+            p_CLKIN1_PERIOD=1e9/f0,
+            i_CLKIN2=0,
+            p_CLKIN2_PERIOD=0.,
+            i_CLKINSEL=1,
+            # Feedback
+            i_CLKFBIN=pll_fb, o_CLKFBOUT=pll_fb, o_LOCKED=pll_lckd,
+            p_CLK_FEEDBACK="CLKFBOUT",
+            p_CLKFBOUT_MULT=18, p_CLKFBOUT_PHASE=0.,
+            # (300MHz) sdram wr rd
+            o_CLKOUT0=unbuf_sdram_full, p_CLKOUT0_DUTY_CYCLE=.5,
+            p_CLKOUT0_PHASE=0., p_CLKOUT0_DIVIDE=3,
+            # unused (available)
+            o_CLKOUT1=unbuf_unused, p_CLKOUT1_DUTY_CYCLE=.5,
+            p_CLKOUT1_PHASE=0., p_CLKOUT1_DIVIDE=6,
+            # (150MHz) sdram_half - sdram dqs adr ctrl
+            o_CLKOUT2=unbuf_sdram_half_a, p_CLKOUT2_DUTY_CYCLE=.5,
+            p_CLKOUT2_PHASE=270., p_CLKOUT2_DIVIDE=6,
+            # (150Hz) off-chip ddr
+            o_CLKOUT3=unbuf_sdram_half_b, p_CLKOUT3_DUTY_CYCLE=.5,
+            p_CLKOUT3_PHASE=250., p_CLKOUT3_DIVIDE=6,
+            # ( 75MHz) periph
+            o_CLKOUT4=unbuf_periph, p_CLKOUT4_DUTY_CYCLE=.5,
+            p_CLKOUT4_PHASE=0., p_CLKOUT4_DIVIDE=12,
+            # ( 75MHz) sysclk
+            o_CLKOUT5=unbuf_sys, p_CLKOUT5_DUTY_CYCLE=.5,
+            p_CLKOUT5_PHASE=0., p_CLKOUT5_DIVIDE=12,
+        )
+
+
+        # power on reset
+        reset = ~platform.request("cpu_reset",0) | self.reset
+        self.clock_domains.cd_por = ClockDomain()
+        por = Signal(max=1 << 11, reset=(1 << 11) - 1)
+        self.sync.por += If(por != 0, por.eq(por - 1))
+        self.specials += AsyncResetSynchronizer(self.cd_por, reset)
+
+        # System clock - 75MHz
+        self.specials += Instance("BUFG", name="sys_bufg", i_I=unbuf_sys, o_O=self.cd_sys.clk)
+        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
+        self.specials += AsyncResetSynchronizer(self.cd_sys, ~pll_lckd | (por > 0))
+
+
+        # SDRAM clocks
+        # ------------------------------------------------------------------------------
+        self.clk4x_wr_strb = Signal()
+        self.clk4x_rd_strb = Signal()
+
+        # sdram_full
+        self.specials += Instance("BUFPLL", name="sdram_full_bufpll",
+                                  p_DIVIDE=4,
+                                  i_PLLIN=unbuf_sdram_full, i_GCLK=self.cd_sys.clk,
+                                  i_LOCKED=pll_lckd,
+                                  o_IOCLK=self.cd_sdram_full_wr.clk,
+                                  o_SERDESSTROBE=self.clk4x_wr_strb)
+        self.comb += [
+            self.cd_sdram_full_rd.clk.eq(self.cd_sdram_full_wr.clk),
+            self.clk4x_rd_strb.eq(self.clk4x_wr_strb),
+        ]
+        # sdram_half
+        self.specials += Instance("BUFG", 
+                                  name="sdram_half_a_bufpll", 
+                                  i_I=unbuf_sdram_half_a, 
+                                  o_O=self.cd_sdram_half.clk)
+        clk_sdram_half_shifted = Signal()
+        self.specials += Instance("BUFG", 
+                                  name="sdram_half_b_bufpll", 
+                                  i_I=unbuf_sdram_half_b, 
+                                  o_O=clk_sdram_half_shifted)
+
+        output_clk = Signal()
+        clk = platform.request("ddram_clock")
+        self.specials += Instance("ODDR2", p_DDR_ALIGNMENT="NONE",
+                                  p_INIT=0, p_SRTYPE="SYNC",
+                                  i_D0=1, i_D1=0, i_S=0, i_R=0, i_CE=1,
+                                  i_C0=clk_sdram_half_shifted,
+                                  i_C1=~clk_sdram_half_shifted,
+                                  o_Q=output_clk)
+        self.specials += Instance("OBUFDS", i_I=output_clk, o_O=clk.p, o_OB=clk.n)
+
+
+class BaseSoC(SoCSDRAM):
+    csr_peripherals = (
+        "spiflash",
+        "ddrphy",
+        "info",
+        "cas",
+    )
+    csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
+
+    mem_map = {
+        "spiflash": 0x20000000,  # (default shadow @0xa0000000)
+    }
+    mem_map.update(SoCSDRAM.mem_map)
+
+    def __init__(self, platform, **kwargs):
+        if 'integrated_rom_size' not in kwargs:
+            kwargs['integrated_rom_size']=0x8000
+        if 'integrated_sram_size' not in kwargs:
+            kwargs['integrated_sram_size']=0x4000
+
+        kwargs['uart_baudrate']=230400
+
+        clk_freq = 75*1000*1000
+
+        SoCSDRAM.__init__(self, platform, clk_freq, **kwargs)
+
+        self.submodules.crg = _CRG(platform, clk_freq)
+        self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/clk_freq)
+
+        # Basic peripherals
+        self.submodules.info = info.Info(platform, self.__class__.__name__)
+        self.submodules.cas = cas.ControlAndStatus(platform, clk_freq)
+
+        # spi flash
+        self.submodules.spiflash = spi_flash.SpiFlashSingle(
+            platform.request("spiflash"),
+            dummy=platform.spiflash_read_dummy_bits,
+            div=platform.spiflash_clock_div)
+        self.add_constant("SPIFLASH_PAGE_SIZE", platform.spiflash_page_size)
+        self.add_constant("SPIFLASH_SECTOR_SIZE", platform.spiflash_sector_size)
+        self.register_mem("spiflash", self.mem_map["spiflash"],
+            self.spiflash.bus, size=platform.spiflash_total_size)
+
+        bios_size = 0x8000
+        self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
+        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
+
+        # sdram
+        sdram_module = MT47H32M16(self.clk_freq, "1:2")
+        self.submodules.ddrphy = s6ddrphy.S6HalfRateDDRPHY(
+            platform.request("ddram"),
+            sdram_module.memtype,
+            rd_bitslip=0,
+            wr_bitslip=4,
+            dqs_ddr_alignment="C0")
+        controller_settings = ControllerSettings(with_bandwidth=True)
+        self.register_sdram(self.ddrphy,
+                            sdram_module.geom_settings,
+                            sdram_module.timing_settings,
+                            controller_settings=controller_settings)
+        self.comb += [
+            self.ddrphy.clk4x_wr_strb.eq(self.crg.clk4x_wr_strb),
+            self.ddrphy.clk4x_rd_strb.eq(self.crg.clk4x_rd_strb),
+        ]
+
+SoC = BaseSoC


### PR DESCRIPTION
Adding basic support for MATRIX Voice (https://www.matrix.one/products/voice)

Support includes:  
* 75MHz system clock
* DDR2 (300MHz)
* UART to Raspberry Pi (230400 baud)
* GPIO connector (P2)
* 8MB SPI FLASH memory
* Debug LED

Passed tests:
* **PICORV32** and **VEXRISC** has been tested, 
* **micropython** was tested on both softcores,
*  **Zephyr** OS was tested on  **VEXRISC** lite. 



