### PR TITLE
Allow to boot Linux from flash

### DIFF
--- a/scripts/build-renode.sh
+++ b/scripts/build-renode.sh
@@ -39,6 +39,7 @@ case $CPU in
 		;;
 esac
 
+LITEX_RENODE="$TOP_DIR/third_party/litex-renode"
 LITEX_CONFIG_FILE="$TARGET_BUILD_DIR/test/csr.csv"
 if [ ! -f "$LITEX_CONFIG_FILE" ]; then
 	make firmware
@@ -75,12 +76,25 @@ RENODE_RESC="$RENODE_SCRIPTS_DIR/litex_buildenv.resc"
 RENODE_REPL="$RENODE_SCRIPTS_DIR/litex_buildenv.repl"
 
 mkdir -p $RENODE_SCRIPTS_DIR
-python $TOP_DIR/third_party/litex-renode/generate-renode-scripts.py $LITEX_CONFIG_FILE \
-	--repl "$RENODE_REPL" \
-	--resc "$RENODE_RESC" \
-	--bios-binary "$TARGET_BUILD_DIR/software/bios/bios.bin" \
-	--firmware-binary "$TARGET_BUILD_DIR/software/$FIRMWARE/firmware.bin" \
-	--configure-network ${TAP_INTERFACE:-""}
+
+if [ "$FIRMWARE" == "linux" ]; then
+	python $LITEX_RENODE/generate-renode-scripts.py $LITEX_CONFIG_FILE \
+		--repl "$RENODE_REPL" \
+		--resc "$RENODE_RESC" \
+		--bios-binary "$TARGET_BUILD_DIR/software/bios/bios.bin" \
+		--flash-binary "$TARGET_BUILD_DIR/software/linux/firmware.bin:kernel_image_flash_offset" \
+		--flash-binary "$TARGET_BUILD_DIR/software/linux/riscv32-rootfs.cpio:rootfs_image_flash_offset"\
+		--flash-binary "$TARGET_BUILD_DIR/software/linux/rv32.dtb:device_tree_image_flash_offset" \
+		--flash-binary "$TARGET_BUILD_DIR/emulator/emulator.bin:emulator_image_flash_offset" \
+		--configure-network ${TAP_INTERFACE:-""}
+else
+	python $LITEX_RENODE/generate-renode-scripts.py $LITEX_CONFIG_FILE \
+		--repl "$RENODE_REPL" \
+		--resc "$RENODE_RESC" \
+		--bios-binary "$TARGET_BUILD_DIR/software/bios/bios.bin" \
+		--firmware-binary "$TARGET_BUILD_DIR/software/$FIRMWARE/firmware.bin" \
+		--configure-network ${TAP_INTERFACE:-""}
+fi
 
 # 1. include the generated script
 # 2. set additional parameters

--- a/targets/arty/base.py
+++ b/targets/arty/base.py
@@ -12,7 +12,7 @@ from gateware import cas
 from gateware import info
 from gateware import spi_flash
 
-from targets.utils import period_ns, dict_set_max
+from targets.utils import period_ns, dict_set_max, define_flash_constants
 from .crg import _CRG
 
 
@@ -93,7 +93,7 @@ class BaseSoC(SoCSDRAM):
 
         bios_size = 0x8000
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
-        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
+        define_flash_constants(self)
 
         # Support for soft-emulation for full Linux support ----------------------------------------
         if self.cpu_type == "vexriscv" and self.cpu_variant == "linux":

--- a/targets/atlys/base.py
+++ b/targets/atlys/base.py
@@ -14,7 +14,7 @@ from litedram.core import ControllerSettings
 from gateware import info
 from gateware import spi_flash
 
-from targets.utils import dict_set_max
+from targets.utils import dict_set_max, define_flash_constants
 from .crg import _CRG
 
 
@@ -94,7 +94,7 @@ class BaseSoC(SoCSDRAM):
 
         bios_size = 0x8000
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
-        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
+        define_flash_constants(self)
 
         # Support for soft-emulation for full Linux support ----------------------------------------
         if self.cpu_type == "vexriscv" and self.cpu_variant == "linux":

--- a/targets/ice40_hx8k_b_evn/base.py
+++ b/targets/ice40_hx8k_b_evn/base.py
@@ -14,7 +14,7 @@ from gateware import cas
 from gateware import info
 from gateware import spi_flash
 
-from targets.utils import dict_set_max, platform_toolchain_extend, round_up_to_4
+from targets.utils import dict_set_max, platform_toolchain_extend, round_up_to_4, define_flash_constants
 
 from .crg import _CRG
 
@@ -127,7 +127,7 @@ Gateware size: {:08x}
             type="cached+linker")
 
         self.flash_boot_address = spiflash_user_base
-        self.add_constant("FLASH_BOOT_ADDRESS", spiflash_user_base)
+        define_flash_constants(self)
 
         # Make the LEDs flash ----------------------------------------------------------------------
         cnt = Signal(32)

--- a/targets/ice40_up5k_b_evn/base.py
+++ b/targets/ice40_up5k_b_evn/base.py
@@ -14,6 +14,7 @@ from gateware import cas
 from gateware import ice40
 from gateware import spi_flash
 
+from targets.utils import define_flash_constants
 import platforms.ice40_up5k_b_evn as up5k
 
 
@@ -99,7 +100,7 @@ class BaseSoC(SoCCore):
             "rom", kwargs['cpu_reset_address'], bios_size,
             type="cached+linker")
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
-        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
+        define_flash_constants(self)
 
         # SPRAM- UP5K has single port RAM, might as well use it as SRAM to
         # free up scarce block RAM.

--- a/targets/icebreaker/base.py
+++ b/targets/icebreaker/base.py
@@ -15,6 +15,7 @@ from gateware import ice40
 from gateware import cas
 from gateware import spi_flash
 
+from targets.utils import define_flash_constants
 from platforms import icebreaker
 
 
@@ -111,7 +112,7 @@ class BaseSoC(SoCCore):
             "rom", kwargs['cpu_reset_address'], bios_size,
             type="cached+linker")
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
-        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
+        define_flash_constants(self)
 
         # SPRAM- UP5K has single port RAM, might as well use it as SRAM to
         # free up scarce block RAM.

--- a/targets/icefun/base.py
+++ b/targets/icefun/base.py
@@ -13,7 +13,7 @@ from litex.soc.integration.builder import *
 from gateware import cas
 from gateware import spi_flash
 
-from targets.utils import dict_set_max
+from targets.utils import dict_set_max, define_flash_constants
 
 
 class _CRG(Module):
@@ -84,7 +84,7 @@ class BaseSoC(SoCCore):
             "rom", kwargs['cpu_reset_address'], bios_size,
             type="cached+linker")
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
-        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
+        define_flash_constants(self)
 
         # We don't have a DRAM, so use the remaining SPI flash for user
         # program.

--- a/targets/mimasv2/base.py
+++ b/targets/mimasv2/base.py
@@ -16,7 +16,7 @@ from gateware import cas
 from gateware import info
 from gateware import spi_flash
 
-from targets.utils import dict_set_max
+from targets.utils import dict_set_max, define_flash_constants
 from .crg import _CRG
 
 
@@ -105,7 +105,7 @@ class BaseSoC(SoCSDRAM):
             "rom", kwargs['cpu_reset_address'], bios_size,
             type="cached+linker")
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
-        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
+        define_flash_constants(self)
 
 
 SoC = BaseSoC

--- a/targets/minispartan6/base.py
+++ b/targets/minispartan6/base.py
@@ -12,7 +12,7 @@ from gateware import cas
 from gateware import info
 from gateware import spi_flash
 
-from targets.utils import dict_set_max
+from targets.utils import dict_set_max, define_flash_constants
 from .crg import _CRG
 
 
@@ -87,7 +87,7 @@ class BaseSoC(SoCSDRAM):
             "rom", kwargs['cpu_reset_address'], bios_size,
             type="cached+linker")
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
-        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
+        define_flash_constants(self)
 
 
 SoC = BaseSoC

--- a/targets/opsis/base.py
+++ b/targets/opsis/base.py
@@ -23,7 +23,7 @@ from gateware import spi_flash
 
 from .crg import _CRG
 
-from targets.utils import dict_set_max
+from targets.utils import dict_set_max, define_flash_constants
 
 
 class FrontPanelGPIO(Module, AutoCSR):
@@ -158,7 +158,7 @@ class BaseSoC(SoCSDRAM):
 
         bios_size = 0x8000
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
-        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
+        define_flash_constants(self)
 
         # Support for soft-emulation for full Linux support ----------------------------------------
         if self.cpu_type == "vexriscv" and self.cpu_variant == "linux":

--- a/targets/pipistrello/base.py
+++ b/targets/pipistrello/base.py
@@ -16,7 +16,7 @@ from litedram.core import ControllerSettings
 from gateware import info
 from gateware import spi_flash
 
-from targets.utils import dict_set_max
+from targets.utils import dict_set_max, define_flash_constants
 from .crg import _CRG
 
 
@@ -96,7 +96,7 @@ class BaseSoC(SoCSDRAM):
 
         bios_size = 0x8000
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
-        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
+        define_flash_constants(self)
 
         # Support for soft-emulation for full Linux support ----------------------------------------
         if self.cpu_type == "vexriscv" and self.cpu_variant == "linux":

--- a/targets/sim/base.py
+++ b/targets/sim/base.py
@@ -13,7 +13,7 @@ from litedram.core.controller import ControllerSettings
 
 from gateware import firmware
 
-from targets.utils import dict_set_max
+from targets.utils import dict_set_max, define_flash_constants
 
 
 class BaseSoC(SoCSDRAM):
@@ -42,7 +42,7 @@ class BaseSoC(SoCSDRAM):
         self.submodules.firmware_ram = firmware.FirmwareROM(firmware_ram_size, firmware_filename)
         self.register_mem("firmware_ram", self.mem_map["firmware_ram"], self.firmware_ram.bus, firmware_ram_size)
         self.flash_boot_address = self.mem_map["firmware_ram"]
-        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
+        define_flash_constants(self)
 
         # sdram
         sdram_module = IS42S16160(self.clk_freq, "1:1")

--- a/targets/tinyfpga_bx/base.py
+++ b/targets/tinyfpga_bx/base.py
@@ -12,7 +12,7 @@ from litex.soc.integration.builder import *
 from gateware import cas
 from gateware import spi_flash
 
-from targets.utils import dict_set_max
+from targets.utils import dict_set_max, define_flash_constants
 from .crg import _CRG
 
 
@@ -70,7 +70,7 @@ class BaseSoC(SoCCore):
             "rom", kwargs['cpu_reset_address'], bios_size,
             type="cached+linker")
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size+platform.bootloader_size
-        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
+        define_flash_constants(self)
 
         # We don't have a DRAM, so use the remaining SPI flash for user
         # program.

--- a/targets/upduino_v1/base.py
+++ b/targets/upduino_v1/base.py
@@ -15,6 +15,7 @@ from gateware import cas
 from gateware import ice40
 from gateware import spi_flash
 
+from targets.utils import define_flash_constants
 import platforms.upduino_v1 as upduino
 
 
@@ -85,7 +86,7 @@ class BaseSoC(SoCCore):
             "rom", kwargs['cpu_reset_address'], bios_size,
             type="cached+linker")
         self.flash_boot_address = self.mem_map["spiflash"]+platform.gateware_size+bios_size
-        self.add_constant("FLASH_BOOT_ADDRESS", self.flash_boot_address)
+        define_flash_constants(self)
 
         # SPRAM- UP5K has single port RAM, might as well use it as SRAM to
         # free up scarce block RAM.

--- a/targets/utils.py
+++ b/targets/utils.py
@@ -139,6 +139,14 @@ def platform_toolchain_extend(platform, cmdname, argument):
     bt.clear()
     bt.extend(_platform_toolchain_cmd_join(cmds))
 
+def define_flash_constants(soc):
+    soc.add_constant("FLASH_BOOT_ADDRESS", soc.flash_boot_address)
+    if soc.cpu_variant == "linux":
+        soc.add_constant("KERNEL_IMAGE_FLASH_OFFSET", 0x00000000)
+        soc.add_constant("ROOTFS_IMAGE_FLASH_OFFSET", 0x00500000)
+        soc.add_constant("DEVICE_TREE_IMAGE_FLASH_OFFSET", 0x00D00000)
+        soc.add_constant("EMULATOR_IMAGE_FLASH_OFFSET", 0x00D80000)
+
 
 if __name__ == "__main__":
     import doctest


### PR DESCRIPTION
This PR adds the definition of flash layout for Linux binaries (required for the offsets to be included in the LiteX configuration `csr.csv` file) and modifies `scripts/build-renode.sh` script so it now loads them.

NOTE:  This requires https://github.com/litex-hub/litex-renode/pull/22 to merged first!