### PR TITLE
micropython: use fupy/micropython fork

### DIFF
--- a/scripts/build-micropython.sh
+++ b/scripts/build-micropython.sh
@@ -48,7 +48,7 @@ MPY_SRC_DIR=$TOP_DIR/third_party/micropython
 if [ ! -d "$MPY_SRC_DIR" ]; then
 	(
 		cd $(dirname $MPY_SRC_DIR)
-		git clone -b modern-litex https://github.com/ewenmcneill/fupy-micropython.git micropython
+		git clone https://github.com/fupy/micropython.git
 		cd $MPY_SRC_DIR
 		git submodule update --init
 	)


### PR DESCRIPTION
This reverts commit 421a402a68824dda81395c58675c1d55c21a0261
as the current fupy/micropython no more contains the
problematic `hw` directory.