### PR TITLE
Add emulator_ram to fix CPU_VARIANT=linux build for pano_logic_g2.

### DIFF
--- a/targets/pano_logic_g2/base.py
+++ b/targets/pano_logic_g2/base.py
@@ -20,6 +20,7 @@ from targets.utils import dict_set_max
 class BaseSoC(SoCSDRAM):
     mem_map = {**SoCSDRAM.mem_map, **{
         'spiflash': 0x20000000,
+        'emulator_ram': 0x50000000,
     }}
 
     def __init__(self, platform, **kwargs):


### PR DESCRIPTION
(builds and runs BIOS, I haven't been able to get Linux to run yet)