### PR TITLE
Fix errors when scripts are called by Makefile, apply patches only once.

### DIFF
--- a/scripts/build-common.sh
+++ b/scripts/build-common.sh
@@ -13,7 +13,7 @@ function init {
     fi
 
     # Imports TARGET, PLATFORM, CPU and TARGET_BUILD_DIR from Makefile
-    eval $(make env)
+    eval $(make --silent env)
     make info
 
     source $SCRIPT_DIR/settings.sh

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -27,7 +27,7 @@ if [ -z "$HDMI2USB_ENV" ]; then
 fi
 
 # Imports TARGET, PLATFORM, CPU and TARGET_BUILD_DIR from Makefile
-eval $(make env)
+eval $(make --silent env)
 make info
 
 set -x
@@ -175,7 +175,10 @@ if [ ${CPU} = vexriscv ]; then
 
 		# this is a temp fix for building the emulator
 		cd $TOP_DIR/third_party/litex/litex/soc/cores/cpu/vexriscv/verilog/ext/VexRiscv
-		git am $TOP_DIR/patches/0001-emulator-Use-external-hw-common.h-from-LiteX.patch
+                if [ ! -e .patched ]; then
+		    git am $TOP_DIR/patches/0001-emulator-Use-external-hw-common.h-from-LiteX.patch
+                    touch .patched
+                fi
 
 		cd $TOP_DIR/third_party/litex/litex/soc/cores/cpu/vexriscv/verilog/ext/VexRiscv/src/main/c/emulator
 

--- a/scripts/build-micropython.sh
+++ b/scripts/build-micropython.sh
@@ -27,7 +27,7 @@ if [ -z "$HDMI2USB_ENV" ]; then
 fi
 
 # Imports TARGET, PLATFORM, CPU and TARGET_BUILD_DIR from Makefile
-eval $(make env)
+eval $(make --silent env)
 make info
 
 set -x

--- a/scripts/build-zephyr.sh
+++ b/scripts/build-zephyr.sh
@@ -27,7 +27,7 @@ if [ -z "$HDMI2USB_ENV" ]; then
 fi
 
 # Imports TARGET, PLATFORM, CPU and TARGET_BUILD_DIR from Makefile
-eval $(make env)
+eval $(make --silent env)
 make info
 
 source $SCRIPT_DIR/settings.sh

--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -274,7 +274,7 @@ export PATH=$CONDA_DIR/bin:$PATH:/sbin
 	conda info
 )
 
-eval $(cd $TOP_DIR; export HDMI2USB_ENV=1; make env || exit 1) || exit 1
+eval $(cd $TOP_DIR; export HDMI2USB_ENV=1; make --silent env || exit 1) || exit 1
 (
 	cd $TOP_DIR
 	export HDMI2USB_ENV=1
@@ -699,3 +699,5 @@ echo "-----------------------"
 echo ""
 echo "Completed.  To load environment:"
 echo "source $SETUP_DIR/enter-env.sh"
+# Set a flag indicating successfully script completion
+touch ${BUILD_DIR}/.env_downloaded

--- a/scripts/download-prebuilt.sh
+++ b/scripts/download-prebuilt.sh
@@ -27,7 +27,7 @@ if [ -z "$HDMI2USB_ENV" ]; then
 fi
 
 # Imports TARGET, PLATFORM, CPU and TARGET_BUILD_DIR from Makefile
-eval $(make env)
+eval $(make --silent env)
 
 if [ -d $TARGET_BUILD_DIR ]; then
 	echo "Build directory '$TARGET_BUILD_DIR' already exists."

--- a/scripts/enter-env.sh
+++ b/scripts/enter-env.sh
@@ -197,7 +197,7 @@ export PYTHONNOUSERSITE=1
 # Install and setup conda for downloading packages
 export PATH=$CONDA_DIR/bin:$PATH:/sbin
 
-eval $(cd $TOP_DIR; export HDMI2USB_ENV=1; make env || exit 1) || return 1
+eval $(cd $TOP_DIR; export HDMI2USB_ENV=1; make --silent env || exit 1) || return 1
 (
 	cd $TOP_DIR
 	export HDMI2USB_ENV=1


### PR DESCRIPTION
Original issues:

1. When scripts were run from an external Makefile they failed because make prints "make[1]: Leaving directory ..." so eval tired to run "make[1]" which of course failed.

2. build-linux.sh only worked on the first run because it attempts to apply patches to already patched sources.