### PR TITLE
Optionally allow checkout commits and BR2_EXTERNAL to be specified.

### DIFF
--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -235,6 +235,10 @@ if [ ${CPU} = vexriscv ] && [ ${BUILD_BUILDROOT:-0} = 1 ]; then
 			cd $(dirname $BD_SRC)
 			echo "Downloading Buildroot code."
 			git clone $BD_REMOTE $BD_SRC
+			cd $BD_SRC
+			if [ x$BD_COMMIT != x ]; then
+			    git checkout $BD_COMMIT
+			fi
 		)
 		fi
 
@@ -243,6 +247,9 @@ if [ ${CPU} = vexriscv ] && [ ${BUILD_BUILDROOT:-0} = 1 ]; then
 			cd $(dirname $LLV_SRC)
 			echo "Downloading Linux on LiteX-VexRiscv code."
 			git clone $LLV_REMOTE $LLV_SRC
+			if [ x$LLV_COMMIT != x ]; then
+			    (cd $LLV_SRC; git checkout $LLV_COMMIT)
+			fi
 		)
 		fi
 
@@ -258,7 +265,11 @@ if [ ${CPU} = vexriscv ] && [ ${BUILD_BUILDROOT:-0} = 1 ]; then
 		dtc -I dts -O dtb -o $TARGET_LINUX_BUILD_DIR/rv32.dtb $TARGET_LINUX_BUILD_DIR/rv32.dts
 
 		cd $BD_SRC
-		make BR2_EXTERNAL=$LLV_SRC/buildroot/ litex_vexriscv_defconfig
+                if [ "x$BR2_EXTERNAL" = "x" ]; then
+		    make BR2_EXTERNAL=$LLV_SRC/buildroot/ litex_vexriscv_defconfig
+		else
+		    make litex_vexriscv_defconfig
+		fi
 		time make
 		ls -l $BD_SRC/output/images/
 		ln -sf $BD_SRC/output/images/Image $TOP_DIR/$FIRMWARE_FILEBASE.bin

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -235,9 +235,8 @@ if [ ${CPU} = vexriscv ] && [ ${BUILD_BUILDROOT:-0} = 1 ]; then
 			cd $(dirname $BD_SRC)
 			echo "Downloading Buildroot code."
 			git clone $BD_REMOTE $BD_SRC
-			cd $BD_SRC
 			if [ x$BD_COMMIT != x ]; then
-			    git checkout $BD_COMMIT
+			    (cd $BD_SRC; git checkout $BD_COMMIT)
 			fi
 		)
 		fi
@@ -265,10 +264,10 @@ if [ ${CPU} = vexriscv ] && [ ${BUILD_BUILDROOT:-0} = 1 ]; then
 		dtc -I dts -O dtb -o $TARGET_LINUX_BUILD_DIR/rv32.dtb $TARGET_LINUX_BUILD_DIR/rv32.dts
 
 		cd $BD_SRC
-                if [ "x$BR2_EXTERNAL" = "x" ]; then
-		    make BR2_EXTERNAL=$LLV_SRC/buildroot/ litex_vexriscv_defconfig
-		else
+		if [ "$(bash -c 'echo ${x$BR2_EXTERNAL}')" ]; then
 		    make litex_vexriscv_defconfig
+		else
+		    make BR2_EXTERNAL=$LLV_SRC/buildroot/ litex_vexriscv_defconfig
 		fi
 		time make
 		ls -l $BD_SRC/output/images/

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -264,11 +264,7 @@ if [ ${CPU} = vexriscv ] && [ ${BUILD_BUILDROOT:-0} = 1 ]; then
 		dtc -I dts -O dtb -o $TARGET_LINUX_BUILD_DIR/rv32.dtb $TARGET_LINUX_BUILD_DIR/rv32.dts
 
 		cd $BD_SRC
-		if [ "$(bash -c 'echo ${x$BR2_EXTERNAL}')" ]; then
-		    make litex_vexriscv_defconfig
-		else
-		    make BR2_EXTERNAL=$LLV_SRC/buildroot/ litex_vexriscv_defconfig
-		fi
+		make BR2_EXTERNAL=${BR2_EXTERNAL:-$LLV_SRC/buildroot} litex_vexriscv_defconfig
 		time make
 		ls -l $BD_SRC/output/images/
 		ln -sf $BD_SRC/output/images/Image $TOP_DIR/$FIRMWARE_FILEBASE.bin


### PR DESCRIPTION
Recent commits to linux-on-litex-vexriscv for SMP broke Linux for the Pano Logic platform.  These changes allow the linux-on-litex-vexriscv and the buildroot repositories to be checked out from specific (known working) commits.  

If BD_COMMIT, LLV_COMMIT and BR2_EXTERNAL are not set in the environment then the script behavior is unchanged.

Allowing BR2_EXTERNAL to be specified in the environment makes it possible to use a customized buildroot configuration for a specific platform.  For example to enable DHCP on eth0.

See https://github.com/skiphansen/panog2_linux/blob/master/Makefile for an example of how this can be used.
