### PR TITLE
Set Xilinx gateware toolchain location

### DIFF
--- a/.travis/download-xilinx.sh
+++ b/.travis/download-xilinx.sh
@@ -111,9 +111,6 @@ if [ $HAVE_XILINX_ISE -eq 1 -o $HAVE_XILINX_VIVADO -eq 1 ]; then
 else
 	export HAVE_XILINX_TOOLCHAIN=0
 fi
-if [ $HAVE_XILINX_TOOLCHAIN -eq 1 ]; then
-	export MISOC_EXTRA_CMDLINE="-Ob toolchain_path $XILINX_DIR/opt/Xilinx/"
-fi
 
 # Detect a likely lack of license early, but just warn if it's missing
 # just in case they've set it up elsewhere.

--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -352,6 +352,7 @@ case $PLATFORM_TOOLCHAIN in
 			fi
 			echo ""
 			export HAVE_XILINX_ISE=1
+			export LITEX_ENV_ISE=$(dirname ${XILINX_SETTINGS_ISE[0]})
 		else
 			echo "                             - *No* Xilinx ISE toolchain found"
 			export HAVE_XILINX_ISE=0
@@ -363,6 +364,7 @@ case $PLATFORM_TOOLCHAIN in
 			fi
 			echo ""
 			export HAVE_XILINX_VIVADO=1
+			export LITEX_ENV_VIVADO=$(dirname ${XILINX_SETTINGS_VIVADO[0]})
 		else
 			echo "                             - *No* Xilinx Vivado toolchain found!"
 			export HAVE_XILINX_VIVADO=0
@@ -374,11 +376,6 @@ case $PLATFORM_TOOLCHAIN in
 			echo "                             - *No* Xilinx toolchain found!"
 			export HAVE_XILINX_TOOLCHAIN=0
 			export HAVE_FPGA_TOOLCHAIN=0
-		fi
-		if [ $HAVE_XILINX_TOOLCHAIN -eq 1 ]; then
-    		        for P in ${XILINX_BINDIR[@]}; do
-        		 	export PATH="$XILINX_DIR/$P:$PATH"
-		 	done
 		fi
 
 		# Detect a likely lack of license early, but just warn if it's missing

--- a/scripts/enter-env.sh
+++ b/scripts/enter-env.sh
@@ -275,6 +275,7 @@ case $PLATFORM_TOOLCHAIN in
 			fi
 			echo ""
 			export HAVE_XILINX_ISE=1
+			export LITEX_ENV_ISE=$(dirname ${XILINX_SETTINGS_ISE[0]})
 		else
 			echo "                             - *No* Xilinx ISE toolchain found"
 			export HAVE_XILINX_ISE=0
@@ -286,6 +287,7 @@ case $PLATFORM_TOOLCHAIN in
 			fi
 			echo ""
 			export HAVE_XILINX_VIVADO=1
+			export LITEX_ENV_VIVADO=$(dirname ${XILINX_SETTINGS_VIVADO[0]})
 		else
 			echo "                             - *No* Xilinx Vivado toolchain found!"
 			export HAVE_XILINX_VIVADO=0
@@ -297,11 +299,6 @@ case $PLATFORM_TOOLCHAIN in
 			echo "                             - *No* Xilinx toolchain found!"
 			export HAVE_XILINX_TOOLCHAIN=0
 			export HAVE_FPGA_TOOLCHAIN=0
-		fi
-		if [ $HAVE_XILINX_TOOLCHAIN -eq 1 ]; then
-    		        for P in ${XILINX_BINDIR[@]}; do
-        		 	export PATH="$XILINX_DIR/$P:$PATH"
-		 	done
 		fi
 
 		# Detect a likely lack of license early, but just warn if it's missing


### PR DESCRIPTION
This is necessary in order to source Xilinx settings
in automatically generated toolchain scripts.