### PR TITLE
download-env: Fix the installation of some python modules

### DIFF
--- a/scripts/download-env.sh
+++ b/scripts/download-env.sh
@@ -654,24 +654,6 @@ echo "Installing robotframework (python module)"
 pip install robotframework==3.0.4
 check_import robot
 
-(
-cd $THIRD_DIR
-
-cd pythondata-software-compiler_rt
-echo "Installing pythondata-software-compiler_rt (local python module)"
-python setup.py develop
-cd ..
-
-check_import pythondata_software_compiler_rt
-
-
-cd pythondata-cpu-$CPU
-echo "Installing pythondata-cpu-$CPU (local python module)"
-python setup.py develop
-cd ..
-
-check_import pythondata_cpu_$CPU
-)
 
 # git commands
 echo ""
@@ -710,6 +692,25 @@ for LITE in $LITE_REPOS; do
 	)
 	check_import $LITE_MOD
 done
+
+(
+cd $THIRD_DIR
+
+cd pythondata-software-compiler_rt
+echo "Installing pythondata-software-compiler_rt (local python module)"
+python setup.py develop
+cd ..
+
+check_import pythondata_software_compiler_rt
+
+
+cd pythondata-cpu-$CPU
+echo "Installing pythondata-cpu-$CPU (local python module)"
+python setup.py develop
+cd ..
+
+check_import pythondata_cpu_$CPU
+)
 
 echo "-----------------------"
 echo ""


### PR DESCRIPTION
Submodules must be initialized and updated before installing
pythondata-software-compiler_rt and python-cpu.