### PR TITLE
Fix typo for CAS rgb_led in a couple platforms (arty, cmod_a7).

### DIFF
--- a/platforms/arty.py
+++ b/platforms/arty.py
@@ -12,7 +12,7 @@ _io = [
     ("user_led", 2, Pins("T9"), IOStandard("LVCMOS33")),
     ("user_led", 3, Pins("T10"), IOStandard("LVCMOS33")),
 
-    ("rgb_leds", 0,
+    ("rgb_led", 0,
         Subsignal("r", Pins("G6 G3 J3 K1")),
         Subsignal("g", Pins("F6 J4 J2 H6")),
         Subsignal("b", Pins("E1 G4 H4 K2")),

--- a/platforms/cmod_a7.py
+++ b/platforms/cmod_a7.py
@@ -16,7 +16,7 @@ _io = [
     #set_property -dict { PACKAGE_PIN B17   IOSTANDARD LVCMOS33 } [get_ports { led0_b }]; #IO_L14N_T2_SRCC_16 Sch=led0_b
     #set_property -dict { PACKAGE_PIN B16   IOSTANDARD LVCMOS33 } [get_ports { led0_g }]; #IO_L13N_T2_MRCC_16 Sch=led0_g
     #set_property -dict { PACKAGE_PIN C17   IOSTANDARD LVCMOS33 } [get_ports { led0_r }]; #IO_L14P_T2_SRCC_16 Sch=led0_r
-    ("rgb_leds", 0,
+    ("rgb_led", 0,
         Subsignal("r", Pins("C17")),
         Subsignal("g", Pins("B16")),
         Subsignal("b", Pins("B17")),


### PR DESCRIPTION
These platforms used "rgb_leds", but the routine in gateware/cas.py uses "rgb_led", so no RGB LED IOs were being generated for these platforms.   This fixes that.

Signed-off-by: Tim Callahan <tcal@google.com>