### PR TITLE
Add minimal target for Arty Board platform

### DIFF
--- a/platforms/arty.py
+++ b/platforms/arty.py
@@ -121,7 +121,7 @@ class Platform(XilinxPlatform):
     spiflash_sector_size = 0x10000
 
     def __init__(self, toolchain="vivado", programmer="openocd"):
-        XilinxPlatform.__init__(self, "xc7a35t-csg324-1", _io,
+        XilinxPlatform.__init__(self, "xc7a35ticsg324-1L", _io,
                                 toolchain=toolchain)
         self.toolchain.bitstream_commands = \
             ["set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]"]

--- a/targets/arty/minimal.py
+++ b/targets/arty/minimal.py
@@ -1,0 +1,38 @@
+from migen import *
+
+from litex.soc.cores.clock import *
+from litex.boards.platforms import arty
+from litex.soc.integration.soc_core import *
+from litex.soc.cores.led import LedChaser
+
+
+class _CRG(Module):
+    def __init__(self, platform, sys_clk_freq):
+        self.rst = Signal()
+        self.clock_domains.cd_sys       = ClockDomain()
+        self.clock_domains.cd_sys4x     = ClockDomain(reset_less=True)
+        self.clock_domains.cd_sys4x_dqs = ClockDomain(reset_less=True)
+        self.clock_domains.cd_idelay    = ClockDomain()
+
+        self.submodules.pll = pll = S7PLL(speedgrade=-1)
+        self.comb += pll.reset.eq(~platform.request("cpu_reset") | self.rst)
+        pll.register_clkin(platform.request("clk100"), 100e6)
+        pll.create_clkout(self.cd_sys,       sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x,     4*sys_clk_freq)
+        pll.create_clkout(self.cd_sys4x_dqs, 4*sys_clk_freq, phase=90)
+        pll.create_clkout(self.cd_idelay,    200e6)
+
+
+class MinimalSoC(SoCCore):
+    def __init__(self, platform, **kwargs):
+        sys_clk_freq=int(60e6)
+        SoCCore.__init__(self, platform, sys_clk_freq, **kwargs)
+
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+        self.submodules.leds = LedChaser(
+            pads         = platform.request_all("user_led"),
+            sys_clk_freq = sys_clk_freq)
+        self.add_csr("leds")
+
+
+SoC = MinimalSoC


### PR DESCRIPTION
This commit adds a simple `minimal` target for the Arty board. The target is used to demonstrate the SymbiFlow toolchain usage with the `litex-buildenv` project. Custom target is needed since the default `BaseSoC` class uses DNA, which is not supported by SymbiFlow. 

Additionally, this PR changes the Arty Board `part` name. The same chip version is used in the main LiteX repository:
https://github.com/enjoy-digital/litex/blob/master/litex/boards/platforms/arty.py#L317


The detailed description about SymbiFlow usage prepared for the Wiki is available [[HERE]](https://storage.googleapis.com/symbiflow-scratch/rw1nkler/litex-buildenv/symbiflow.md)